### PR TITLE
Fix Tech Queue bug

### DIFF
--- a/includes/functions/HandlePlanetQueue_TechnologySetNext.php
+++ b/includes/functions/HandlePlanetQueue_TechnologySetNext.php
@@ -78,7 +78,7 @@ function HandlePlanetQueue_TechnologySetNext(&$ThePlanet, &$TheUser, $CurrentTim
 				$ThePlanet['techQueue'] = implode(';', $Queue);
 				$ThePlanet['techQueue_firstEndTime'] = $ElementEndTime;
 				$TheUser['techQueue_Planet'] = $ThePlanet['id'];
-				$TheUser['techQueue_firstEndTime'] = $ElementEndTime;
+				$TheUser['techQueue_EndTime'] = $ElementEndTime;
 
 				$UserDev_Log[] = array('PlanetID' => $ThePlanet['id'], 'Date' => $CurrentTime, 'Place' => 4, 'Code' => 1, 'ElementID' => $ElementID);
 


### PR DESCRIPTION
Fixes "invisible" tech queue progress when being on another planet than the main one (where "main one" is the planet conducting the research).
This bug would allow users to put lower level techs in the queue, which led to cheaper technological advancement.

Fixes https://github.com/mdziekon/UniEngine/issues/1