### PR TITLE
Fix fleet quick missions in non Pro-account mode

### DIFF
--- a/fleet.php
+++ b/fleet.php
@@ -1148,7 +1148,7 @@ else
     $_Lang['P_Mission'] = (isset($_GET['target_mission']) ? intval($_GET['target_mission']) : null);
     if(isset($_GET['quickres']) && $_GET['quickres'] == 1)
     {
-        if(isset($_GET['target_mission']) && $_GET['target_mission'] != 3)
+        if(!isset($_GET['target_mission']) || $_GET['target_mission'] != 3)
         {
             if($_User['settings_mainPlanetID'] != $_Planet['id'])
             {

--- a/fleet.php
+++ b/fleet.php
@@ -1146,7 +1146,7 @@ else
     $_Lang['P_Planet'] = (isset($_GET['planet']) ? intval($_GET['planet']) : null);
     $_Lang['P_PlType'] = (isset($_GET['planettype']) ? intval($_GET['planettype']) : null);
     $_Lang['P_Mission'] = (isset($_GET['target_mission']) ? intval($_GET['target_mission']) : null);
-    if(isset($_GET['quickres']))
+    if(isset($_GET['quickres']) && $_GET['quickres'] == 1)
     {
         if(isset($_GET['target_mission']) && $_GET['target_mission'] != 3)
         {


### PR DESCRIPTION
Related to #29 

TODO:
- [x] Fix incorrect read on ``quickres`` parameter, causing all quick missions (eg. from the Galaxy view) to be incorrectly filled out when in non-Pro-account mode.
- [x] Fix incorrect auto-fill of "Transport all resources" when selecting "transport to the main planet" option (from the ``Fleet`` section)