### PR TITLE
Morale system droptime calculation bugfix

### DIFF
--- a/includes/debug.class.php
+++ b/includes/debug.class.php
@@ -11,8 +11,11 @@ class DBErrorHandler {
 
         if ($this->isHandlingError) {
             throw new RuntimeException(
-                "DBErrorHandler: Nesting Prevention!\n" .
-                $this->lastErrorMessage
+                "DBErrorHandler: Nesting Prevention!\n\n" .
+                "Previous error message:\n" .
+                $this->lastErrorMessage . "\n\n" .
+                "Latest error message:\n" .
+                $message
             );
         }
 

--- a/includes/debug.class.php
+++ b/includes/debug.class.php
@@ -60,6 +60,8 @@ class DBErrorHandler {
             $SQLQuery_InsertError
         );
 
+        $_DBLink->query('UNLOCK TABLES; -- debug.class.php');
+
         $_DBLink->query($SQLQuery_InsertError);
 
         if ($_DBLink->errno) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -269,7 +269,9 @@ function Morale_ReCalculate(&$TheUser, $TheTime = false)
 
 function Morale_AddMorale(&$TheUser, $Type, $Factor, $LevelFactor = 1, $TimeFactor = 1, $TheTime = false)
 {
-    $AddLevel = floor((($Factor > MORALE_MAXIMALFACTOR ? MORALE_MAXIMALFACTOR : $Factor) / 2) * $LevelFactor) * $Type;
+    $effectiveFactor = ($Factor > MORALE_MAXIMALFACTOR ? MORALE_MAXIMALFACTOR : $Factor);
+
+    $AddLevel = floor(($effectiveFactor / 2) * $LevelFactor) * $Type;
     if($AddLevel == 0)
     {
         return false;
@@ -280,7 +282,7 @@ function Morale_AddMorale(&$TheUser, $Type, $Factor, $LevelFactor = 1, $TimeFact
         $TheTime = time();
     }
 
-    $AddTime = floor($Factor * 3600 * $TimeFactor);
+    $AddTime = floor($effectiveFactor * 3600 * $TimeFactor);
 
     $NewMoralePositive = ($AddLevel > 0 ? true : false);
     $OldMoralePositive = ($TheUser['morale_level'] > 0 ? true : false);


### PR DESCRIPTION
Closes #47

### Changelog:
- [x] Fixed the morale system's droptime calculation, by preventing the additional time to be calculated as ``INF``
- [x] Error reporting code now unlocks all tables
- [x] Error reporting code now shows both errors when nesting occurs