### PR TITLE
Session cookie key fix

### DIFF
--- a/common.php
+++ b/common.php
@@ -235,7 +235,7 @@ if(isLogged())
 
     if($_User['dokick'] == 1)
     {
-        setcookie($_GameConfig['COOKIE_NAME'], '', $Common_TimeNow - 100000, '/', '', 0);
+        setcookie(getSessionCookieKey(), '', $Common_TimeNow - 100000, '/', '', 0);
         doquery("UPDATE {{table}} SET `dokick` = 0 WHERE `id` = {$_User['id']};", 'users');
 
         header('Location: logout.php?kicked=1');

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -27,6 +27,19 @@ function SecureInput($Input)
     return $Input;
 }
 
+function getSessionCookieKey() {
+    global $_GameConfig;
+
+    $key = $_GameConfig['COOKIE_NAME'];
+
+    // PHP internally replaces spaces (" ") and dots (".") with underscores ("_")
+    // when setting cookie values in $_COOKIE. We have to map the stored key
+    // to read the correct value from the array.
+    $key = preg_replace('/(\s|\.)/', '_', $key);
+
+    return $key;
+}
+
 function isPro($_User = false)
 {
     if($_User === false)

--- a/includes/functions/CheckUserSessionCookie.php
+++ b/includes/functions/CheckUserSessionCookie.php
@@ -19,9 +19,12 @@ function CheckUserSessionCookie()
     {
         require($_EnginePath.'config.php');
     }
-    if(isset($_COOKIE[$_GameConfig['COOKIE_NAME']]))
+
+    $sessionCookieKey = getSessionCookieKey();
+
+    if(isset($_COOKIE[$sessionCookieKey]))
     {
-        $TheCookie = explode('/%/', $_COOKIE[$_GameConfig['COOKIE_NAME']]);
+        $TheCookie = explode('/%/', $_COOKIE[$sessionCookieKey]);
         $TheCookie[0] = intval($TheCookie[0]);
         if($TheCookie[0] <= 0)
         {
@@ -86,8 +89,8 @@ function CheckUserSessionCookie()
 
         Tasks_CheckUservar($UserRow);
 
-        setcookie($_GameConfig['COOKIE_NAME'], FALSE, 0, '/', '.'.GAMEURL_DOMAIN);
-        setcookie($_GameConfig['COOKIE_NAME'], $NextCookie, $ExpireTime, '/', '', false, true);
+        setcookie($sessionCookieKey, FALSE, 0, '/', '.'.GAMEURL_DOMAIN);
+        setcookie($sessionCookieKey, $NextCookie, $ExpireTime, '/', '', false, true);
     }
     unset($__ServerConnectionSettings);
     $_DontShowMenus = $Init['$_DontShowMenus'];

--- a/install/index.php
+++ b/install/index.php
@@ -281,6 +281,12 @@ if (!$_Install_SaveRegisterJS) {
     die();
 }
 
+$sessionCookieName = $_Install_Vars['uni_gamename'];
+$sessionCookieName = strtoupper($sessionCookieName);
+$sessionCookieName = preg_replace('/\s+/', '_', $sessionCookieName);
+$sessionCookieName = preg_replace('/\.+/', '_', $sessionCookieName);
+$sessionCookieName = $sessionCookieName . '_CK';
+
 // Now, final try - call every query
 $_Install_QueriesData = [
     'prefix'                                        => $_Install_Vars['dbconfig_prefix'],
@@ -292,10 +298,7 @@ $_Install_QueriesData = [
     'Config_DefenseDebris'                          => $_Install_Vars['uni_defensedebris'],
     'Config_MissileDebris'                          => $_Install_Vars['uni_missiledebris'],
     'Config_InitialFields'                          => $_Install_Vars['uni_motherfields'],
-    'Config_CookieName'                             => (
-        preg_replace('/\s+/', '', strtoupper($_Install_Vars['uni_gamename'])) .
-        '_CK'
-    ),
+    'Config_CookieName'                             => $sessionCookieName,
     'Config_NoobProtection_Enable'                  => (
         $_Install_Vars['uni_noobprt_enable'] ?
         '1' :

--- a/login.php
+++ b/login.php
@@ -10,6 +10,8 @@ include($_EnginePath.'common.php');
 
 includeLang('login');
 
+$sessionCookieKey = getSessionCookieKey();
+
 if(!empty($_GET['post']))
 {
     $_POST = unserialize(base64_decode($_GET['post']));
@@ -68,9 +70,9 @@ if($_POST)
         $Search['error'] = 1;
     }
 }
-elseif(!empty($_COOKIE[$_GameConfig['COOKIE_NAME']]))
+elseif(!empty($_COOKIE[$sessionCookieKey]))
 {
-    $explodeCookie = explode('/%/', $_COOKIE[$_GameConfig['COOKIE_NAME']]);
+    $explodeCookie = explode('/%/', $_COOKIE[$sessionCookieKey]);
     $UserID = intval($explodeCookie[0]);
     if($UserID > 0)
     {
@@ -129,7 +131,7 @@ if(!empty($Search['where']))
                     $Cookie_Remember = 0;
                 }
                 $Cookie_Set = $UserData['id'].'/%/'.$UserData['username'].'/%/'.md5($UserData['password'].'--'.$__ServerConnectionSettings['secretword']).'/%/'.$Cookie_Remember;
-                setcookie($_GameConfig['COOKIE_NAME'], $Cookie_Set, $Cookie_Expire, '/', '', false, true);
+                setcookie($sessionCookieKey, $Cookie_Set, $Cookie_Expire, '/', '', false, true);
             }
             IPandUA_Logger($UserData);
             unset($__ServerConnectionSettings);
@@ -164,7 +166,7 @@ if(!empty($Search['error']))
     }
     if($Search['mode'] == 2)
     {
-        setcookie($_GameConfig['COOKIE_NAME'], false, 0, '/', '');
+        setcookie($sessionCookieKey, false, 0, '/', '');
     }
     if($Search['error'] == 1)
     {

--- a/logout.php
+++ b/logout.php
@@ -13,7 +13,7 @@ include($_EnginePath.'common.php');
 loggedCheck();
 includeLang('logout');
 
-setcookie($_GameConfig['COOKIE_NAME'], '', time() - 100000, '/', '', 0);
+setcookie(getSessionCookieKey(), '', time() - 100000, '/', '', 0);
 
 if(isset($_GET['kicked']))
 {

--- a/reg_ajax.php
+++ b/reg_ajax.php
@@ -483,7 +483,10 @@ if(isset($_GET['register']))
                 }
                 $cookie = $UserID.'/%/'.$Username.'/%/'.md5(md5($Password).'--'.$__ServerConnectionSettings['secretword']).'/%/0';
                 $JSONResponse['Code'] = 1;
-                $JSONResponse['Cookie'][] = array('Name' => $_GameConfig['COOKIE_NAME'], 'Value' => $cookie);
+                $JSONResponse['Cookie'][] = [
+                    'Name' => getSessionCookieKey(),
+                    'Value' => $cookie
+                ];
                 $JSONResponse['Redirect'] = GAMEURL_UNISTRICT.'/overview.php';
             }
             else

--- a/settings.php
+++ b/settings.php
@@ -126,7 +126,7 @@ if(!isOnVacation())
                                     $ChangeSet['password'] = md5($_POST['give_newpass']);
                                     $ChangeSetTypes['password'] = 's';
                                     $InfoMsgs[] = $_Lang['Pass_Changed_plzlogout'];
-                                    setcookie($_GameConfig['COOKIE_NAME'], '', $Now - 3600, '/', '');
+                                    setcookie(getSessionCookieKey(), '', $Now - 3600, '/', '');
                                 }
                                 else
                                 {
@@ -1341,7 +1341,7 @@ if(!isOnVacation())
 
             doquery("UPDATE {{table}} SET `darkEnergy` = `darkEnergy` - 10, `username` = '{$NewNick}', `old_username` = '{$_User['username']}', `old_username_expire` = UNIX_TIMESTAMP() + (7*24*60*60) WHERE `id` = {$_User['id']} LIMIT 1;", 'users');
             doquery("INSERT INTO {{table}} VALUES(NULL, {$_User['id']}, UNIX_TIMESTAMP(), '{$NewNick}', '{$_User['username']}');", 'nick_changelog');
-            setcookie($_GameConfig['COOKIE_NAME'], '', $Now - 3600, '/', '');
+            setcookie(getSessionCookieKey(), '', $Now - 3600, '/', '');
             message($_Lang['NewNick_saved'], $_Lang['NickChange_Title'], 'login.php');
         }
         else


### PR DESCRIPTION
Closes #24 

### Changelog:
- [x] Replaces both spaces (`` ``) and dots (``.``) with underscores (``_``) when generating ``COOKIE_NAME`` at installation (for consistency)
- [x] Adds a safeguarded session cookie key getter and uses it across the app to prevent incorrect session cookie key usage