### PR TITLE
Port minor fixes to the codebase from PR #61 | Part 7

### DIFF
--- a/includes/functions/LaboratoryPage.php
+++ b/includes/functions/LaboratoryPage.php
@@ -32,7 +32,6 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
     $TPL['list_disabled']                = gettemplate('buildings_compact_list_disabled');
     $TPL['list_partdisabled']            = parsetemplate($TPL['list_disabled'], array('AddOpacity' => 'dPart'));
     $TPL['list_disabled']                = parsetemplate($TPL['list_disabled'], array('AddOpacity' => ''));
-    $TPL['queue_topinfo']                = gettemplate('buildings_compact_queue_topinfo');
     $TPL['infobox_body']                = gettemplate('buildings_compact_infobox_body_lab');
     $TPL['infobox_levelmodif']            = gettemplate('buildings_compact_infobox_levelmodif');
     $TPL['infobox_req_res']                = gettemplate('buildings_compact_infobox_req_res');

--- a/includes/functions/LaboratoryPage.php
+++ b/includes/functions/LaboratoryPage.php
@@ -1,6 +1,7 @@
 <?php
 
 use UniEngine\Engine\Modules\Development\Components\ModernQueue;
+use UniEngine\Engine\Modules\Development\Screens\ResearchListPage\ModernQueuePlanetInfo;
 use UniEngine\Engine\Includes\Helpers\Planets;
 use UniEngine\Engine\Includes\Helpers\Users;
 
@@ -178,6 +179,15 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
     }
     // End of - Execute Commands
 
+    $planetInfoComponent = ModernQueuePlanetInfo\render([
+        'currentPlanet'     => &$CurrentPlanet,
+        'researchPlanet'    => &$ResearchPlanet,
+        'queue'             => Planets\Queues\Research\parseQueueString(
+            $ResearchPlanet['techQueue']
+        ),
+        'timestamp'         => $Now,
+    ]);
+
     $queueComponent = ModernQueue\render([
         'user'              => &$CurrentUser,
         'planet'            => &$ResearchPlanet,
@@ -186,7 +196,9 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
         ),
         'queueMaxLength'    => Users\getMaxResearchQueueLength($CurrentUser),
         'timestamp'         => $Now,
-        'infoComponents'    => [],
+        'infoComponents'    => [
+            $planetInfoComponent['componentHTML']
+        ],
 
         'getQueueElementCancellationLinkHref' => function ($queueElement) {
             $listID = $queueElement['listID'];

--- a/includes/functions/LaboratoryPage.php
+++ b/includes/functions/LaboratoryPage.php
@@ -1,5 +1,9 @@
 <?php
 
+use UniEngine\Engine\Modules\Development\Components\ModernQueue;
+use UniEngine\Engine\Includes\Helpers\Planets;
+use UniEngine\Engine\Includes\Helpers\Users;
+
 function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
 {
     global    $_EnginePath, $_Lang,
@@ -173,6 +177,32 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
         $ResearchInThisLab = true;
     }
     // End of - Execute Commands
+
+    $queueComponent = ModernQueue\render([
+        'user'              => &$CurrentUser,
+        'planet'            => &$ResearchPlanet,
+        'queue'             => Planets\Queues\Research\parseQueueString(
+            $ResearchPlanet['techQueue']
+        ),
+        'queueMaxLength'    => Users\getMaxResearchQueueLength($CurrentUser),
+        'timestamp'         => $Now,
+        'infoComponents'    => [],
+
+        'getQueueElementCancellationLinkHref' => function ($queueElement) {
+            $listID = $queueElement['listID'];
+
+            return buildHref([
+                'path' => 'buildings.php',
+                'query' => [
+                    'mode' => 'research',
+                    'cmd' => 'cancel',
+                    'el' => ($listID - 1)
+                ]
+            ]);
+        }
+    ]);
+
+    $Parse['Create_Queue'] = $queueComponent['componentHTML'];
 
     // Parse Queue
     $CurrentQueue = (isset($ResearchPlanet['techQueue']) ? $ResearchPlanet['techQueue'] : false);

--- a/includes/functions/LaboratoryPage.php
+++ b/includes/functions/LaboratoryPage.php
@@ -143,16 +143,6 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
     }
 
     // Handle Commands
-    // TODO: this should be changed on the queue rendering level
-    if (
-        isset($_GET) &&
-        isset($_GET['cmd']) &&
-        $_GET['cmd'] === 'cancel' &&
-        !isset($_GET['el'])
-    ) {
-        $_GET['el'] = '0';
-    }
-
     $cmdResult = UniEngine\Engine\Modules\Development\Input\UserCommands\handleResearchCommand(
         $CurrentUser,
         $ResearchPlanet,

--- a/includes/functions/StructuresBuildingPage.php
+++ b/includes/functions/StructuresBuildingPage.php
@@ -3,6 +3,9 @@
 use UniEngine\Engine\Modules\Development;
 use UniEngine\Engine\Includes\Helpers\World\Elements;
 use UniEngine\Engine\Includes\Helpers\World\Resources;
+use UniEngine\Engine\Modules\Development\Components\ModernQueue;
+use UniEngine\Engine\Includes\Helpers\Planets;
+use UniEngine\Engine\Includes\Helpers\Users;
 
 function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
 {
@@ -53,6 +56,31 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
         $ShowElementID = $cmdResult['payload']['elementID'];
     }
     // End of - Handle Commands
+
+    $queueComponent = ModernQueue\render([
+        'planet' => &$CurrentPlanet,
+        'queue' => Planets\Queues\Structures\parseQueueString($CurrentPlanet['buildQueue']),
+        'queueMaxLength' => Users\getMaxStructuresQueueLength($CurrentUser),
+        'timestamp' => $Now,
+        'infoComponents' => [],
+
+        'getQueueElementCancellationLinkHref' => function ($queueElement) {
+            $queueElementIdx = $queueElement['queueElementIdx'];
+            $listID = $queueElement['listID'];
+            $isFirstQueueElement = ($queueElementIdx === 0);
+            $cmd = ($isFirstQueueElement ? "cancel" : "remove");
+
+            return buildHref([
+                'path' => 'buildings.php',
+                'query' => [
+                    'cmd' => $cmd,
+                    'listid' => $listID
+                ]
+            ]);
+        }
+    ]);
+
+    $Parse['Create_Queue'] = $queueComponent['componentHTML'];
 
     // Parse Queue
     $CurrentQueue = $CurrentPlanet['buildQueue'];

--- a/includes/functions/StructuresBuildingPage.php
+++ b/includes/functions/StructuresBuildingPage.php
@@ -10,7 +10,7 @@ use UniEngine\Engine\Includes\Helpers\Users;
 function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
 {
     global    $_Lang, $_SkinPath, $_GameConfig, $_GET, $_EnginePath,
-            $_Vars_GameElements, $_Vars_ElementCategories, $_Vars_MaxElementLevel, $_Vars_PremiumBuildings, $_Vars_IndestructibleBuildings;
+            $_Vars_GameElements, $_Vars_ElementCategories, $_Vars_MaxElementLevel, $_Vars_IndestructibleBuildings;
 
     include($_EnginePath.'includes/functions/GetElementTechReq.php');
     includeLang('worldElements.detailed');
@@ -34,7 +34,6 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
     $TPL['list_disabled']                = gettemplate('buildings_compact_list_disabled');
     $TPL['list_partdisabled']            = parsetemplate($TPL['list_disabled'], array('AddOpacity' => 'dPart'));
     $TPL['list_disabled']                = parsetemplate($TPL['list_disabled'], array('AddOpacity' => ''));
-    $TPL['queue_topinfo']                = gettemplate('buildings_compact_queue_topinfo');
     $TPL['infobox_body']                = gettemplate('buildings_compact_infobox_body_structures');
     $TPL['infobox_levelmodif']            = gettemplate('buildings_compact_infobox_levelmodif');
     $TPL['infobox_req_res']                = gettemplate('buildings_compact_infobox_req_res');
@@ -84,146 +83,55 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
 
     // Parse Queue
     $CurrentQueue = $CurrentPlanet['buildQueue'];
-    if(!empty($CurrentQueue))
-    {
+    if (!empty($CurrentQueue)) {
         $LockResources['metal'] = 0;
         $LockResources['crystal'] = 0;
         $LockResources['deuterium'] = 0;
 
         $CurrentQueue = explode(';', $CurrentQueue);
         $QueueIndex = 0;
-        foreach($CurrentQueue as $QueueID => $QueueData)
-        {
+
+        foreach ($CurrentQueue as $QueueID => $QueueData) {
             $QueueData = explode(',', $QueueData);
             $BuildEndTime = $QueueData[3];
-            if($BuildEndTime >= $Now)
-            {
-                $ListID = $QueueIndex + 1;
-                $ElementID = $QueueData[0];
-                $ElementLevel = $QueueData[1];
-                $ElementMode = $QueueData[4];
-                $ElementBuildtime = $BuildEndTime - $Now;
-                $ElementName = $_Lang['tech'][$ElementID];
-                if($ElementMode != 'build')
-                {
-                    $ElementLevel += 1;
-                    $ElementModeColor = 'red';
-                    $ThisForDestroy = true;
-                }
-                else
-                {
-                    $ElementModeColor = 'lime';
-                    $ThisForDestroy = false;
-                }
-                if($QueueIndex == 0)
-                {
-                    include($_EnginePath.'/includes/functions/InsertJavaScriptChronoApplet.php');
 
-                    $QueueParser[] = array
-                    (
-                        'ChronoAppletScript'    => InsertJavaScriptChronoApplet(
-                            'QueueFirstTimer',
-                            '',
-                            $BuildEndTime,
-                            true,
-                            false,
-                            'function() { onQueuesFirstElementFinished(); }'
-                        ),
-                        'EndTimer'                => pretty_time($ElementBuildtime, true),
-                        'SkinPath'                => $_SkinPath,
-                        'ElementID'                => $ElementID,
-                        'Name'                    => $ElementName,
-                        'LevelText'                => $_Lang['level'],
-                        'Level'                    => $ElementLevel,
-                        'ModeText'                => ($ThisForDestroy ? $_Lang['Queue_Mode_Destroy_1'] : $_Lang['Queue_Mode_Build_1']),
-                        'ModeColor'                => $ElementModeColor,
-                        'EndText'                => $_Lang['Queue_EndTime'],
-                        'EndDate'                => date('d/m | H:i:s', $BuildEndTime),
-                        'EndTitleBeg'            => $_Lang['Queue_EndTitleBeg'],
-                        'EndTitleHour'            => $_Lang['Queue_EndTitleHour'],
-                        'EndDateExpand'            => prettyDate('d m Y', $BuildEndTime, 1),
-                        'EndTimeExpand'            => date('H:i:s', $BuildEndTime),
-                        'PremBlock'                => (isset($_Vars_PremiumBuildings[$ElementID]) && $_Vars_PremiumBuildings[$ElementID] == 1 ? 'premblock' : ''),
-                        'ListID'                => $ListID,
-                        'PlanetID'                => $CurrentPlanet['id'],
-                        'CancelText'            => (isset($_Vars_PremiumBuildings[$ElementID]) && $_Vars_PremiumBuildings[$ElementID] == 1 ? $_Lang['Queue_Cancel_CantCancel'] : ($ThisForDestroy ? $_Lang['Queue_Cancel_Destroy'] : $_Lang['Queue_Cancel_Build']))
-                    );
-                }
-                else
-                {
-                    $QueueParser[] = array
-                    (
-                        'ElementNo'            => $ListID,
-                        'ElementID'            => $ElementID,
-                        'Name'                => $ElementName,
-                        'LevelText'            => $_Lang['level'],
-                        'Level'                => $ElementLevel,
-                        'ModeText'            => ($ThisForDestroy ? $_Lang['Queue_Mode_Destroy_1+'] : $_Lang['Queue_Mode_Build_1+']),
-                        'ModeColor'            => $ElementModeColor,
-                        'EndDate'            => date('d/m H:i:s', $BuildEndTime),
-                        'EndTitleBeg'        => $_Lang['Queue_EndTitleBeg'],
-                        'EndTitleHour'        => $_Lang['Queue_EndTitleHour'],
-                        'EndDateExpand'        => prettyDate('d m Y', $BuildEndTime, 1),
-                        'EndTimeExpand'        => date('H:i:s', $BuildEndTime),
-                        'InfoBox_BuildTime' => ($ThisForDestroy ? $_Lang['InfoBox_DestroyTime'] : $_Lang['InfoBox_BuildTime']),
-                        'BuildTime'            => pretty_time($BuildEndTime - $PreviousBuildEndTime),
-                        'ListID'            => $ListID,
-                        'PlanetID'            => $CurrentPlanet['id'],
-                        'RemoveText'        => $_Lang['Queue_Cancel_Remove']
-                    );
-
-                    $GetResourcesToLock = GetBuildingPrice($CurrentUser, $CurrentPlanet, $ElementID, true, $ThisForDestroy);
-                    $LockResources['metal'] += $GetResourcesToLock['metal'];
-                    $LockResources['crystal'] += $GetResourcesToLock['crystal'];
-                    $LockResources['deuterium'] += $GetResourcesToLock['deuterium'];
-                }
-
-                if(!isset($LevelModifiers[$ElementID]))
-                {
-                    $LevelModifiers[$ElementID] = 0;
-                }
-                if($ThisForDestroy)
-                {
-                    $LevelModifiers[$ElementID] += 1;
-                    $CurrentPlanet[$_Vars_GameElements[$ElementID]] -= 1;
-                    $FieldsModifier += 2;
-                }
-                else
-                {
-                    $LevelModifiers[$ElementID] -= 1;
-                    $CurrentPlanet[$_Vars_GameElements[$ElementID]] += 1;
-                }
-
-                $QueueIndex += 1;
+            if ($BuildEndTime < $Now) {
+                continue;
             }
-            $PreviousBuildEndTime = $BuildEndTime;
+
+            $ElementID = $QueueData[0];
+            $ElementMode = $QueueData[4];
+            $ThisForDestroy = ($ElementMode != 'build');
+
+            if ($QueueIndex != 0) {
+                $GetResourcesToLock = GetBuildingPrice($CurrentUser, $CurrentPlanet, $ElementID, true, $ThisForDestroy);
+                $LockResources['metal'] += $GetResourcesToLock['metal'];
+                $LockResources['crystal'] += $GetResourcesToLock['crystal'];
+                $LockResources['deuterium'] += $GetResourcesToLock['deuterium'];
+            }
+
+            if (!isset($LevelModifiers[$ElementID])) {
+                $LevelModifiers[$ElementID] = 0;
+            }
+            if ($ThisForDestroy) {
+                $LevelModifiers[$ElementID] += 1;
+                $CurrentPlanet[$_Vars_GameElements[$ElementID]] -= 1;
+                $FieldsModifier += 2;
+            } else {
+                $LevelModifiers[$ElementID] -= 1;
+                $CurrentPlanet[$_Vars_GameElements[$ElementID]] += 1;
+            }
+
+            $QueueIndex += 1;
         }
+
         $CurrentPlanet['metal'] -= (isset($LockResources['metal']) ? $LockResources['metal'] : 0);
         $CurrentPlanet['crystal'] -= (isset($LockResources['crystal']) ? $LockResources['crystal'] : 0);
         $CurrentPlanet['deuterium'] -= (isset($LockResources['deuterium']) ? $LockResources['deuterium'] : 0);
 
         $Queue['lenght'] = $QueueIndex;
-        if(!empty($QueueParser))
-        {
-            $Parse['Create_Queue'] = '';
-            foreach($QueueParser as $QueueID => $QueueData)
-            {
-                if($QueueID == 0)
-                {
-                    $ThisTPL = gettemplate('buildings_compact_queue_firstel');
-                }
-                else if($QueueID == 1)
-                {
-                    $ThisTPL = gettemplate('buildings_compact_queue_nextel');
-                }
-                $Parse['Create_Queue'] .= parsetemplate($ThisTPL, $QueueData);
-            }
-        }
-    }
-    else
-    {
+    } else {
         $Queue['lenght'] = 0;
-        $Parse['Create_Queue'] = parsetemplate($TPL['queue_topinfo'], array('InfoText' => $_Lang['Queue_Empty']));
     }
     // End of - Parse Queue
 
@@ -243,7 +151,6 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
     else
     {
         $CanAddToQueue = false;
-        $Parse['Create_Queue'] = parsetemplate($TPL['queue_topinfo'], array('InfoColor' => 'red', 'InfoText' => $_Lang['Queue_Full'])).$Parse['Create_Queue'];
     }
     if($CurrentUser['engineer_time'] > $Now)
     {

--- a/includes/unlocalised.php
+++ b/includes/unlocalised.php
@@ -28,6 +28,12 @@ function gettemplate($templatename)
     return ReadFromFile($_EnginePath . UNIENGINE_TEMPLATE_DIR . UNIENGINE_TEMPLATE_NAME . '/' . $templatename . '.tpl');
 }
 
+function createLocalTemplateLoader($loaderDirPath) {
+    return function ($templateName) use ($loaderDirPath) {
+        return ReadFromFile($loaderDirPath . '/' . $templateName . '.tpl');
+    };
+}
+
 function getDefaultUniLang() {
     if (defined('UNI_DEFAULT_LANG')) {
         return UNI_DEFAULT_LANG;

--- a/language/en/buildings.lang
+++ b/language/en/buildings.lang
@@ -91,7 +91,7 @@ $_Lang['InfoBox_ResearchTime']                  = 'Research time';
 $_Lang['Queue_Cancel_Research']                 = 'Cancel research';
 $_Lang['Queue_ResearchOn']                      = 'Research conducted on ';
 $_Lang['Queue_CantCancel_Premium_Lab']          = 'You cannot cancel research which required Dark Energy!';
-$_Lang['Queue_LabInQueue']                      = 'Queue is locked!<br/>Research lab is being upgraded on planets:<br/>%s';
+$_Lang['Queue_LabInQueue']                      = 'Queue is locked!<br/>Research lab is being upgraded on planets:';
 
 $_Lang['Queue_ListView_Info']                   = 'Research queue is available only when using the Grid Layout!';
 

--- a/language/pl/buildings.lang
+++ b/language/pl/buildings.lang
@@ -89,7 +89,7 @@ $_Lang['InfoBox_ResearchTime']          = 'Czas badania';
 $_Lang['Queue_Cancel_Research']         = 'Przerwij badanie';
 $_Lang['Queue_ResearchOn']              = 'Badanie przeprowadzane na';
 $_Lang['Queue_CantCancel_Premium_Lab']  = 'Nie można przerwać badania, które wymagało Ciemnej Energii!';
-$_Lang['Queue_LabInQueue']              = 'Kolejka zablokowana!<br/>Laboratorium w rozbudowie na Planetach:<br/>%s';
+$_Lang['Queue_LabInQueue']              = 'Kolejka zablokowana!<br/>Laboratorium w rozbudowie na Planetach:';
 
 $_Lang['Queue_ListView_Info']           = 'Kolejka Badań jest dostępna tylko w Wyglądzie Kafelkowym!';
 

--- a/modules/development/_includes.php
+++ b/modules/development/_includes.php
@@ -9,6 +9,8 @@ call_user_func(function () {
     include($includePath . './input/research.userCommands.php');
     include($includePath . './input/structures.userCommands.php');
 
+    include($includePath . './components/ModernQueue/ModernQueue.component.php');
+
 });
 
 ?>

--- a/modules/development/_includes.php
+++ b/modules/development/_includes.php
@@ -11,6 +11,8 @@ call_user_func(function () {
 
     include($includePath . './components/ModernQueue/ModernQueue.component.php');
 
+    include($includePath . './screens/ResearchListPage/ModernQueuePlanetInfo/ModernQueuePlanetInfo.component.php');
+
 });
 
 ?>

--- a/modules/development/_includes.php
+++ b/modules/development/_includes.php
@@ -12,6 +12,7 @@ call_user_func(function () {
     include($includePath . './components/ModernQueue/ModernQueue.component.php');
 
     include($includePath . './screens/ResearchListPage/ModernQueuePlanetInfo/ModernQueuePlanetInfo.component.php');
+    include($includePath . './screens/ResearchListPage/ModernQueueLabUpgradeInfo/ModernQueueLabUpgradeInfo.component.php');
 
 });
 

--- a/modules/development/components/ModernQueue/ModernQueue.component.php
+++ b/modules/development/components/ModernQueue/ModernQueue.component.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Development\Components\ModernQueue;
+
+use UniEngine\Engine\Includes\Helpers\World\Elements;
+
+//  Arguments
+//      - $props (Object)
+//          - planet (Object)
+//          - queue (Array<QueueElement>)
+//              QueueElement: Object
+//                  - elementID (Number)
+//                  - level (Number)
+//                  - duration (Number)
+//                  - endTimestamp (Number)
+//                  - mode (String)
+//          - queueMaxLength (Number)
+//          - timestamp (Number)
+//          - infoComponents (Array<String: componentHTML> | undefined)
+//          - getQueueElementCancellationLinkHref (Function: (ExtendedQueueElement) => String)
+//              ExtendedQueueElement: Object
+//                  - queueElementIdx (Number)
+//                  - listID (Number)
+//                  - elementID (Number)
+//                  - level (Number)
+//                  - duration (Number)
+//                  - endTimestamp (Number)
+//                  - mode (String)
+//
+//  Returns: Object
+//      - componentHTML (String)
+//
+function render ($props) {
+    global $_Lang, $_SkinPath, $_EnginePath;
+
+    includeLang('worldElements.detailed');
+
+    $localTemplateLoader = createLocalTemplateLoader(__DIR__);
+
+    $planet = &$props['planet'];
+    $queue = $props['queue'];
+    $queueMaxLength = $props['queueMaxLength'];
+    $currentTimestamp = $props['timestamp'];
+    $infoComponents = (
+        isset($props['infoComponents']) ?
+        $props['infoComponents'] :
+        []
+    );
+    $getQueueElementCancellationLinkHref = $props['getQueueElementCancellationLinkHref'];
+
+    $componentTPLData = [
+        'queueElements' => [],
+        'queueTopInfobox' => []
+    ];
+    $tplBodyCache = [
+        'row_infobox_generic' => $localTemplateLoader('row_infobox_generic'),
+        'row_element_firstel' => $localTemplateLoader('row_element_firstel'),
+        'row_element_nextel' => $localTemplateLoader('row_element_nextel')
+    ];
+
+    $queueElementsTplData = [];
+    $queueUnfinishedElementsCount = 0;
+
+    foreach ($queue as $queueIdx => $queueElement) {
+        if ($queueElement['endTimestamp'] < $currentTimestamp) {
+            continue;
+        }
+
+        $listID = ($queueUnfinishedElementsCount + 1);
+        $elementID = $queueElement['elementID'];
+        $elementLevel = $queueElement['level'];
+        $progressDuration = $queueElement['duration'];
+        $progressEndTime = $queueElement['endTimestamp'];
+        $progressTimeLeft = $progressEndTime - $currentTimestamp;
+        $isUpgrading = ($queueElement['mode'] == 'build');
+        $isFirstQueueElement = ($queueIdx === 0);
+
+        if (!$isUpgrading) {
+            $elementLevel += 1;
+        }
+
+        $elementCancellableClass = (
+            !Elements\isCancellableOnceInProgress($elementID) ?
+            'premblock' :
+            ''
+        );
+        $elementModeLabelText = (
+            $isUpgrading ?
+            $_Lang['Queue_Mode_Build_1'] :
+            $_Lang['Queue_Mode_Destroy_1']
+        );
+        $elementModeLabelColorClass = (
+            $isUpgrading ?
+            'lime' :
+            'red'
+        );
+        $elementCancelButtonText = (
+            $isFirstQueueElement ?
+            (
+                (!Elements\isCancellableOnceInProgress($elementID)) ?
+                $_Lang['Queue_Cancel_CantCancel'] :
+                (
+                    $isUpgrading ?
+                    $_Lang['Queue_Cancel_Build'] :
+                    $_Lang['Queue_Cancel_Destroy']
+                )
+            ) :
+            $_Lang['Queue_Cancel_Remove']
+        );
+        $elementBuildTimeLabelText = (
+            $isUpgrading ?
+            $_Lang['InfoBox_BuildTime'] :
+            $_Lang['InfoBox_DestroyTime']
+        );
+
+        $elementChronoAppletScript = '';
+
+        if ($isFirstQueueElement) {
+            include_once($_EnginePath . '/includes/functions/InsertJavaScriptChronoApplet.php');
+
+            $elementChronoAppletScript = InsertJavaScriptChronoApplet(
+                'QueueFirstTimer',
+                '',
+                $progressEndTime,
+                true,
+                false,
+                'function() { onQueuesFirstElementFinished(); }'
+            );
+        }
+
+        $queueElementTplData = [
+            'Data_SkinPath'                     => $_SkinPath,
+            'Data_ListID'                       => $listID,
+            'Data_ElementNo'                    => $listID,
+            'Data_ElementID'                    => $elementID,
+            'Data_Name'                         => $_Lang['tech'][$elementID],
+            'Data_Level'                        => $elementLevel,
+            'Data_PlanetID'                     => $planet['id'],
+            'Data_BuildTime'                    => pretty_time($progressDuration),
+            'Data_EndTimer'                     => pretty_time($progressTimeLeft, true, 'D'),
+            'Data_EndTimeExpand'                => date('H:i:s', $progressEndTime),
+            'Data_EndDate'                      => date('d/m | H:i:s', $progressEndTime),
+            'Data_EndDateExpand'                => prettyDate('d m Y', $progressEndTime, 1),
+
+            'Data_RemoveElementFromQueueLinkHref' => $getQueueElementCancellationLinkHref([
+                'queueElementIdx'   => $queueIdx,
+                'listID'            => $listID,
+                'elementID'         => $queueElement['elementID'],
+                'level'             => $queueElement['level'],
+                'duration'          => $queueElement['duration'],
+                'endTimestamp'      => $queueElement['endTimestamp'],
+                'mode'              => $queueElement['mode']
+            ]),
+
+            'Data_ModeText'                     => $elementModeLabelText,
+            'Data_CancelBtn_Text'               => $elementCancelButtonText,
+            'Data_BuildTimeLabel'               => $elementBuildTimeLabelText,
+            'Data_CancelLock_class'             => $elementCancellableClass,
+            'Data_ModeColor'                    => $elementModeLabelColorClass,
+
+            'PHPInject_ChronoAppletScriptCode'  => $elementChronoAppletScript,
+
+            'Lang_LevelText'                    => $_Lang['level'],
+            'Lang_EndText'                      => $_Lang['Queue_EndTime'],
+            'Lang_EndTitleBeg'                  => $_Lang['Queue_EndTitleBeg'],
+            'Lang_EndTitleHour'                 => $_Lang['Queue_EndTitleHour'],
+        ];
+
+        $queueElementsTplData[] = $queueElementTplData;
+
+        $queueUnfinishedElementsCount += 1;
+    }
+
+    if (!empty($queueElementsTplData)) {
+        foreach ($queueElementsTplData as $elementIdx => $queueElementTplData) {
+            $queueElementTPLBody = (
+                $elementIdx === 0 ?
+                $tplBodyCache['row_element_firstel'] :
+                $tplBodyCache['row_element_nextel']
+            );
+
+            $componentTPLData['queueElements'][] = parsetemplate($queueElementTPLBody, $queueElementTplData);
+        }
+    } else {
+        $componentTPLData['queueTopInfobox'][] = parsetemplate(
+            $tplBodyCache['row_infobox_generic'],
+            [
+                'InfoText' => $_Lang['Queue_Empty']
+            ]
+        );
+    }
+
+    $isQueueFull = ($queueUnfinishedElementsCount >= $queueMaxLength);
+
+    if ($isQueueFull) {
+        $queueFullMsgHTML = parsetemplate(
+            $tplBodyCache['row_infobox_generic'],
+            [
+                'InfoColor' => 'red',
+                'InfoText' => $_Lang['Queue_Full']
+            ]
+        );
+
+        $componentTPLData['queueTopInfobox'][] = $queueFullMsgHTML;
+    }
+
+    if (!empty($infoComponents)) {
+        foreach ($infoComponents as $infoComponentHTML) {
+            $componentTPLData['queueTopInfobox'][] = $infoComponentHTML;
+        }
+    }
+
+    $componentHTML = (
+        implode('', $componentTPLData['queueTopInfobox']) .
+        implode('', $componentTPLData['queueElements'])
+    );
+
+    return [
+        'componentHTML' => $componentHTML
+    ];
+}
+
+?>

--- a/modules/development/components/ModernQueue/ModernQueue.component.php
+++ b/modules/development/components/ModernQueue/ModernQueue.component.php
@@ -15,6 +15,7 @@ use UniEngine\Engine\Includes\Helpers\World\Elements;
 //                  - endTimestamp (Number)
 //                  - mode (String)
 //          - queueMaxLength (Number)
+//          - isQueueEmptyInfoHidden (Boolean | undefined)
 //          - timestamp (Number)
 //          - infoComponents (Array<String: componentHTML> | undefined)
 //          - getQueueElementCancellationLinkHref (Function: (ExtendedQueueElement) => String)
@@ -40,6 +41,11 @@ function render ($props) {
     $planet = &$props['planet'];
     $queue = $props['queue'];
     $queueMaxLength = $props['queueMaxLength'];
+    $isQueueEmptyInfoHidden = (
+        isset($props['isQueueEmptyInfoHidden']) ?
+        $props['isQueueEmptyInfoHidden'] :
+        false
+    );
     $currentTimestamp = $props['timestamp'];
     $infoComponents = (
         isset($props['infoComponents']) ?
@@ -181,7 +187,7 @@ function render ($props) {
 
             $componentTPLData['queueElements'][] = parsetemplate($queueElementTPLBody, $queueElementTplData);
         }
-    } else {
+    } else if (!$isQueueEmptyInfoHidden) {
         $componentTPLData['queueTopInfobox'][] = parsetemplate(
             $tplBodyCache['row_infobox_generic'],
             [

--- a/modules/development/components/ModernQueue/index.php
+++ b/modules/development/components/ModernQueue/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/development/components/ModernQueue/row_element_firstel.tpl
+++ b/modules/development/components/ModernQueue/row_element_firstel.tpl
@@ -1,0 +1,74 @@
+{PHPInject_ChronoAppletScriptCode}
+<tr>
+    <th
+        class="pad2"
+        style="font-size: 15px;"
+        id="bxxQueueFirstTimer"
+        colspan="2"
+    >
+        {Data_EndTimer}
+    </th>
+</tr>
+<tr>
+    <th
+        class="pad2"
+        colspan="2"
+    >
+        <table class="w100p">
+            <tr>
+                <td
+                    valign="top"
+                    style="width: 70px;"
+                >
+                    <a href="infos.php?gid={Data_ElementID}">
+                        <img
+                            src="{Data_SkinPath}gebaeude/{Data_ElementID}.gif"
+                            width="64"
+                            height="64"
+                            class="buildImg"
+                        />
+                    </a>
+                </td>
+                <td
+                    style="text-align: left;"
+                    valign="top"
+                >
+                    <a href="infos.php?gid={Data_ElementID}">
+                        <b>{Data_Name}</b>
+                    </a>
+                    <br />
+                    <b>
+                        {Lang_LevelText} {Data_Level},
+                    </b>
+                    <b class="{Data_ModeColor}">
+                        {Data_ModeText}
+                    </b>
+                    <br /><br />
+                    <b>
+                        {Lang_EndText}:
+                    </b>
+                    <b
+                        class="lime endDate"
+                        title="<center>{Lang_EndTitleBeg} {Data_EndDateExpand}<br/>{Lang_EndTitleHour} {Data_EndTimeExpand}</center>"
+                    >
+                        {Data_EndDate}
+                    </b>
+                </td>
+            </tr>
+        </table>
+    </th>
+</tr>
+<tr>
+    <th
+        class="pad2"
+        colspan="2"
+    >
+        <a
+            id="QueueCancel"
+            href="{Data_RemoveElementFromQueueLinkHref}"
+            class="cancelQueue {Data_CancelLock_class}"
+        >
+            {Data_CancelBtn_Text}
+        </a>
+    </th>
+</tr>

--- a/modules/development/components/ModernQueue/row_element_nextel.tpl
+++ b/modules/development/components/ModernQueue/row_element_nextel.tpl
@@ -1,0 +1,34 @@
+<tr class="queueinv">
+    <td colspan="2">&nbsp;</td>
+</tr>
+<tr>
+    <th
+        class="pad2 w20x"
+        rowspan="2"
+    >
+        {Data_ElementNo}
+    </th>
+    <th class="pad2">
+        <a href="infos.php?gid={Data_ElementID}">
+            {Data_Name}
+        </a>
+        ({Lang_LevelText} {Data_Level}, <b class="{Data_ModeColor}">{Data_ModeText}</b>)
+        <br />
+        <b
+            class="lime endDate"
+            title="<center>{Lang_EndTitleBeg} {Data_EndDateExpand}<br/>{Lang_EndTitleHour} {Data_EndTimeExpand}<br/>({Data_BuildTimeLabel}: {Data_BuildTime})</center>"
+        >
+            {Data_EndDate}
+        </b>
+    </th>
+</tr>
+<tr>
+    <th
+        class="pad2"
+        colspan="2"
+    >
+        <a href="{Data_RemoveElementFromQueueLinkHref}">
+            {Data_CancelBtn_Text}
+        </a>
+    </th>
+</tr>

--- a/modules/development/components/ModernQueue/row_infobox_generic.tpl
+++ b/modules/development/components/ModernQueue/row_infobox_generic.tpl
@@ -1,0 +1,1 @@
+<tr><th class="pad5 {InfoColor}" colspan="2">{InfoText}</th></tr>

--- a/modules/development/components/index.php
+++ b/modules/development/components/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/development/screens/ResearchListPage/ModernQueueLabUpgradeInfo/ModernQueueLabUpgradeInfo.component.php
+++ b/modules/development/screens/ResearchListPage/ModernQueueLabUpgradeInfo/ModernQueueLabUpgradeInfo.component.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Development\Screens\ResearchListPage\ModernQueueLabUpgradeInfo;
+
+//  Arguments
+//      - $props (Object)
+//          - planetsWithUnfinishedLabUpgrades
+//
+//  Returns: Object
+//      - componentHTML (String)
+//
+function render ($props) {
+    global $_Lang;
+
+    includeLang('worldElements.detailed');
+
+    $localTemplateLoader = createLocalTemplateLoader(__DIR__);
+
+    $planetsWithUnfinishedLabUpgrades = &$props['planetsWithUnfinishedLabUpgrades'];
+
+    $hasPlanetsWithUnfinishedLabUpgrades = !empty($planetsWithUnfinishedLabUpgrades);
+
+    $tplBodyCache = [
+        'queue_topinfo_planetlink' => $localTemplateLoader('row_infobox_planetlink'),
+        'queue_topinfo_otherplanetbox' => $localTemplateLoader('row_infobox_otherplanetbox'),
+    ];
+
+    if (!$hasPlanetsWithUnfinishedLabUpgrades) {
+        return [
+            'componentHTML' => ''
+        ];
+    }
+
+    $planetLinks = array_map(
+        function ($planet) use (&$tplBodyCache) {
+            $subcomponentTPLData = [
+                'Data_planetID' => $planet['id'],
+                'Data_planetName' => $planet['name'],
+                'Data_planetCoords_galaxy' => $planet['galaxy'],
+                'Data_planetCoords_system' => $planet['system'],
+                'Data_planetCoords_planet' => $planet['planet'],
+            ];
+
+            return parsetemplate(
+                $tplBodyCache['queue_topinfo_planetlink'],
+                $subcomponentTPLData
+            );
+        },
+        $planetsWithUnfinishedLabUpgrades
+    );
+    $planetLinksHTML = implode('<br/>', $planetLinks);
+
+    return [
+        'componentHTML' => parsetemplate(
+            $tplBodyCache['queue_topinfo_otherplanetbox'],
+            [
+                'Lang_LabInQueue' => $_Lang['Queue_LabInQueue'],
+                'Data_planetLinks' => $planetLinksHTML
+            ]
+        )
+    ];
+}
+
+?>

--- a/modules/development/screens/ResearchListPage/ModernQueueLabUpgradeInfo/index.php
+++ b/modules/development/screens/ResearchListPage/ModernQueueLabUpgradeInfo/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/development/screens/ResearchListPage/ModernQueueLabUpgradeInfo/row_infobox_otherplanetbox.tpl
+++ b/modules/development/screens/ResearchListPage/ModernQueueLabUpgradeInfo/row_infobox_otherplanetbox.tpl
@@ -1,0 +1,9 @@
+<tr>
+    <th
+        class="pad5 red"
+        colspan="2"
+    >
+        {Lang_LabInQueue}:<br/>
+        {Data_planetLinks}
+    </th>
+</tr>

--- a/modules/development/screens/ResearchListPage/ModernQueueLabUpgradeInfo/row_infobox_planetlink.tpl
+++ b/modules/development/screens/ResearchListPage/ModernQueueLabUpgradeInfo/row_infobox_planetlink.tpl
@@ -1,0 +1,4 @@
+<a class="orange" href="?cp={Data_planetID}&amp;re=0">
+    {Data_planetName}
+    [{Data_planetCoords_galaxy}:{Data_planetCoords_system}:{Data_planetCoords_planet}]
+</a>

--- a/modules/development/screens/ResearchListPage/ModernQueuePlanetInfo/ModernQueuePlanetInfo.component.php
+++ b/modules/development/screens/ResearchListPage/ModernQueuePlanetInfo/ModernQueuePlanetInfo.component.php
@@ -62,8 +62,8 @@ function render ($props) {
             'orange'
         ),
         'Data_planetCoords_galaxy'      => $researchPlanet['galaxy'],
-        'Data_planetCoords_system'      => $researchPlanet['galaxy'],
-        'Data_planetCoords_planet'      => $researchPlanet['galaxy'],
+        'Data_planetCoords_system'      => $researchPlanet['system'],
+        'Data_planetCoords_planet'      => $researchPlanet['planet'],
 
         'Const_SkinPath'                => $_SkinPath,
         'Lang_ResearchOn'               => $_Lang['Queue_ResearchOn'],

--- a/modules/development/screens/ResearchListPage/ModernQueuePlanetInfo/ModernQueuePlanetInfo.component.php
+++ b/modules/development/screens/ResearchListPage/ModernQueuePlanetInfo/ModernQueuePlanetInfo.component.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Development\Screens\ResearchListPage\ModernQueuePlanetInfo;
+
+//  Arguments
+//      - $props (Object)
+//          - currentPlanet (Object)
+//          - researchPlanet (Object)
+//          - queue (Array<QueueElement>)
+//              QueueElement: Object
+//                  - elementID (Number)
+//                  - level (Number)
+//                  - duration (Number)
+//                  - endTimestamp (Number)
+//                  - mode (String)
+//          - timestamp (Number)
+//
+//  Returns: Object
+//      - componentHTML (String)
+//
+function render ($props) {
+    global $_Lang, $_SkinPath;
+
+    includeLang('worldElements.detailed');
+
+    $localTemplateLoader = createLocalTemplateLoader(__DIR__);
+
+    $currentPlanet = &$props['currentPlanet'];
+    $researchPlanet = &$props['researchPlanet'];
+    $queue = $props['queue'];
+    $currentTimestamp = $props['timestamp'];
+
+    $isResearchConductedOnCurrentPlanet = ($currentPlanet['id'] === $researchPlanet['id']);
+
+    $tplBodyCache = [
+        'queue_topinfo_researchplanet' => $localTemplateLoader('row_infobox_researchplanet'),
+    ];
+
+    $queueUnfinishedElementsCount = 0;
+
+    foreach ($queue as $queueElement) {
+        if ($queueElement['endTimestamp'] < $currentTimestamp) {
+            continue;
+        }
+
+        $queueUnfinishedElementsCount += 1;
+    }
+
+    if ($queueUnfinishedElementsCount === 0) {
+        return [
+            'componentHTML' => ''
+        ];
+    }
+
+    $componentTPLData = [
+        'Data_planetID'                 => $researchPlanet['id'],
+        'Data_planetImg'                => $researchPlanet['image'],
+        'Data_planetName'               => $researchPlanet['name'],
+        'Data_planetLabelColorClass'    => (
+            $isResearchConductedOnCurrentPlanet ?
+            'lime' :
+            'orange'
+        ),
+        'Data_planetCoords_galaxy'      => $researchPlanet['galaxy'],
+        'Data_planetCoords_system'      => $researchPlanet['galaxy'],
+        'Data_planetCoords_planet'      => $researchPlanet['galaxy'],
+
+        'Const_SkinPath'                => $_SkinPath,
+        'Lang_ResearchOn'               => $_Lang['Queue_ResearchOn'],
+    ];
+
+    $componentHTML = parsetemplate(
+        $tplBodyCache['queue_topinfo_researchplanet'],
+        $componentTPLData
+    );
+
+    return [
+        'componentHTML' => $componentHTML
+    ];
+}
+
+?>

--- a/modules/development/screens/ResearchListPage/ModernQueuePlanetInfo/index.php
+++ b/modules/development/screens/ResearchListPage/ModernQueuePlanetInfo/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/development/screens/ResearchListPage/ModernQueuePlanetInfo/row_infobox_researchplanet.tpl
+++ b/modules/development/screens/ResearchListPage/ModernQueuePlanetInfo/row_infobox_researchplanet.tpl
@@ -1,0 +1,34 @@
+<tr>
+    <th
+        class="pad5"
+        colspan="2"
+    >
+        <table class="w100p">
+            <tr>
+                <td
+                    valign="top"
+                    style="width: 70px;"
+                    class="center"
+                >
+                    <a href="?cp={Data_planetID}&amp;mode=research&amp;re=0">
+                        <img
+                            src="{Const_SkinPath}planeten/small/s_{Data_planetImg}.jpg"
+                            width="48"
+                            height="48"
+                            class="buildImg"
+                        />
+                    </a>
+                </td>
+                <td style="text-align: left;">
+                    <b>{Lang_ResearchOn}:</b><br />
+                    <a
+                        class="{Data_planetLabelColorClass}"
+                        href="?cp={Data_planetID}&amp;mode=research&amp;re=0"
+                    >
+                        {Data_planetName} [{Data_planetCoords_galaxy}:{Data_planetCoords_system}:{Data_planetCoords_planet}]
+                    </a>
+                </td>
+            </tr>
+        </table>
+    </th>
+</tr>

--- a/modules/development/screens/ResearchListPage/index.php
+++ b/modules/development/screens/ResearchListPage/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/development/screens/index.php
+++ b/modules/development/screens/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/templates/default_template/buildings_compact_queue_planetlink.tpl
+++ b/templates/default_template/buildings_compact_queue_planetlink.tpl
@@ -1,1 +1,0 @@
-<a class="orange" href="?cp={PlanetID}&amp;re=0">{PlanetName} [{PlanetCoords}]</a>


### PR DESCRIPTION
Part of #63 

Changelog:
- [x] Add new mechanism to load locally placed templates [not part of #61]
- [x] Create the `ModernQueue` component
- [x] Use `ModernQueue` in Structures development view
- [x] Use `ModernQueue` in Research development view
- [x] Remove the temporary workaround for first research queue element cancellation