### PR TITLE
Port minor fixes to the codebase from PR #61 | Part 9

### DIFF
--- a/includes/functions/BatimentBuildingPage.php
+++ b/includes/functions/BatimentBuildingPage.php
@@ -96,13 +96,10 @@ function BatimentBuildingPage(&$CurrentPlanet, $CurrentUser)
         if(in_array($Element, $_Vars_ElementCategories['buildOn'][$CurrentPlanet['planet_type']]))
         {
             $ElementName = $_Lang['tech'][$Element];
-            $CurrentMaxFields = CalculateMaxPlanetFields($CurrentPlanet);
-            if($CurrentPlanet['field_current'] < ($CurrentMaxFields - $buildingsQueueLength))
-            {
+
+            if(($CurrentPlanet['field_current'] + $planetFieldsUsageCounter) < CalculateMaxPlanetFields($CurrentPlanet)) {
                 $RoomIsOk = true;
-            }
-            else
-            {
+            } else {
                 $RoomIsOk = false;
             }
 

--- a/includes/functions/LaboratoryPage.php
+++ b/includes/functions/LaboratoryPage.php
@@ -167,13 +167,14 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
         $ResearchInThisLab = true;
     }
     // End of - Execute Commands
+    $techQueueContent = Planets\Queues\Research\parseQueueString(
+        $ResearchPlanet['techQueue']
+    );
 
     $planetInfoComponent = ModernQueuePlanetInfo\render([
         'currentPlanet'     => &$CurrentPlanet,
         'researchPlanet'    => &$ResearchPlanet,
-        'queue'             => Planets\Queues\Research\parseQueueString(
-            $ResearchPlanet['techQueue']
-        ),
+        'queue'             => $techQueueContent,
         'timestamp'         => $Now,
     ]);
     $labsUpgradeInfoComponent = ModernQueueLabUpgradeInfo\render([
@@ -183,9 +184,7 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
     $queueComponent = ModernQueue\render([
         'user'              => &$CurrentUser,
         'planet'            => &$ResearchPlanet,
-        'queue'             => Planets\Queues\Research\parseQueueString(
-            $ResearchPlanet['techQueue']
-        ),
+        'queue'             => $techQueueContent,
         'queueMaxLength'    => Users\getMaxResearchQueueLength($CurrentUser),
         'timestamp'         => $Now,
         'infoComponents'    => [
@@ -215,9 +214,7 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
     $queueStateDetails = Development\Utils\getQueueStateDetails([
         'queue' => [
             'type' => Development\Utils\QueueType::Technology,
-            'content' => Planets\Queues\Research\parseQueueString(
-                $ResearchPlanet['techQueue']
-            ),
+            'content' => $techQueueContent,
         ],
         'user' => $CurrentUser,
         'planet' => $CurrentPlanet,

--- a/includes/functions/LaboratoryPage.php
+++ b/includes/functions/LaboratoryPage.php
@@ -213,7 +213,7 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
 
     $queueStateDetails = Development\Utils\getQueueStateDetails([
         'queue' => [
-            'type' => Development\Utils\QueueType::Technology,
+            'type' => Development\Utils\QueueType::Research,
             'content' => $techQueueContent,
         ],
         'user' => $CurrentUser,

--- a/includes/functions/LaboratoryPage.php
+++ b/includes/functions/LaboratoryPage.php
@@ -1,10 +1,13 @@
 <?php
 
+use UniEngine\Engine\Modules\Development;
 use UniEngine\Engine\Modules\Development\Components\ModernQueue;
 use UniEngine\Engine\Modules\Development\Screens\ResearchListPage\ModernQueuePlanetInfo;
 use UniEngine\Engine\Modules\Development\Screens\ResearchListPage\ModernQueueLabUpgradeInfo;
 use UniEngine\Engine\Includes\Helpers\Planets;
 use UniEngine\Engine\Includes\Helpers\Users;
+use UniEngine\Engine\Includes\Helpers\World\Resources;
+use UniEngine\Engine\Includes\Helpers\World\Elements;
 
 function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
 {
@@ -209,60 +212,33 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
 
     $Parse['Create_Queue'] = $queueComponent['componentHTML'];
 
-    // Parse Queue
-    $CurrentQueue = (isset($ResearchPlanet['techQueue']) ? $ResearchPlanet['techQueue'] : false);
-    if(!empty($CurrentQueue))
-    {
-        $LockResources['metal'] = 0;
-        $LockResources['crystal'] = 0;
-        $LockResources['deuterium'] = 0;
+    $queueStateDetails = Development\Utils\getQueueStateDetails([
+        'queue' => [
+            'type' => Development\Utils\QueueType::Technology,
+            'content' => Planets\Queues\Research\parseQueueString(
+                $ResearchPlanet['techQueue']
+            ),
+        ],
+        'user' => $CurrentUser,
+        'planet' => $CurrentPlanet,
+    ]);
+    $elementsInQueue = $queueStateDetails['queuedElementsCount'];
 
-        $CurrentQueue = explode(';', $CurrentQueue);
-        $QueueIndex = 0;
-        foreach($CurrentQueue as $QueueID => $QueueData)
-        {
-            $QueueData = explode(',', $QueueData);
-            $BuildEndTime = $QueueData[3];
-
-            if ($BuildEndTime < $Now) {
-                continue;
-            }
-
-            $ElementID = $QueueData[0];
-            if($QueueIndex == 0)
-            {
-                // Do nothing
-            }
-            else
-            {
-                $GetResourcesToLock = GetBuildingPrice($CurrentUser, $CurrentPlanet, $ElementID, true, false);
-                $LockResources['metal'] += $GetResourcesToLock['metal'];
-                $LockResources['crystal'] += $GetResourcesToLock['crystal'];
-                $LockResources['deuterium'] += $GetResourcesToLock['deuterium'];
-            }
-
-            if(!isset($LevelModifiers[$ElementID]))
-            {
-                $LevelModifiers[$ElementID] = 0;
-            }
-            $LevelModifiers[$ElementID] -= 1;
-            $CurrentUser[$_Vars_GameElements[$ElementID]] += 1;
-
-            $QueueIndex += 1;
+    foreach ($queueStateDetails['queuedResourcesToUse'] as $resourceKey => $resourceValue) {
+        if (Resources\isPlanetaryResource($resourceKey)) {
+            $CurrentPlanet[$resourceKey] -= $resourceValue;
+        } else if (Resources\isUserResource($resourceKey)) {
+            $CurrentUser[$resourceKey] -= $resourceValue;
         }
-        $CurrentPlanet['metal'] -= (isset($LockResources['metal']) ? $LockResources['metal'] : 0);
-        $CurrentPlanet['crystal'] -= (isset($LockResources['crystal']) ? $LockResources['crystal'] : 0);
-        $CurrentPlanet['deuterium'] -= (isset($LockResources['deuterium']) ? $LockResources['deuterium'] : 0);
+    }
+    foreach ($queueStateDetails['queuedElementLevelModifiers'] as $elementID => $elementLevelModifier) {
+        $elementKey = Elements\getElementKey($elementID);
+        $CurrentUser[$elementKey] += $elementLevelModifier;
+    }
 
-        $Queue['lenght'] = $QueueIndex;
-    }
-    else
-    {
-        $Queue['lenght'] = 0;
-    }
     if($LabInQueue === false)
     {
-        if($Queue['lenght'] < ((isPro($CurrentUser)) ? MAX_TECH_QUEUE_LENGTH_PRO : MAX_TECH_QUEUE_LENGTH))
+        if($elementsInQueue < ((isPro($CurrentUser)) ? MAX_TECH_QUEUE_LENGTH_PRO : MAX_TECH_QUEUE_LENGTH))
         {
             $CanAddToQueue = true;
         }
@@ -313,6 +289,14 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
 
         $CurrentLevel = $CurrentUser[$_Vars_GameElements[$ElementID]];
         $NextLevel = $CurrentUser[$_Vars_GameElements[$ElementID]] + 1;
+        $isElementInQueue = isset(
+            $queueStateDetails['queuedElementLevelModifiers'][$ElementID]
+        );
+        $elementQueueLevelModifier = (
+            $isElementInQueue ?
+            $queueStateDetails['queuedElementLevelModifiers'][$ElementID] :
+            0
+        );
         $MaxLevelReached = false;
         $TechLevelOK = false;
         $HasResources = true;
@@ -324,15 +308,18 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
         $ElementParser['ElementName'] = $_Lang['tech'][$ElementID];
         $ElementParser['ElementID'] = $ElementID;
         $ElementParser['ElementLevel'] = prettyNumber($CurrentUser[$_Vars_GameElements[$ElementID]]);
-        $ElementParser['ElementRealLevel'] = prettyNumber($CurrentUser[$_Vars_GameElements[$ElementID]] + (isset($LevelModifiers[$ElementID]) ? $LevelModifiers[$ElementID] : 0));
+        $ElementParser['ElementRealLevel'] = prettyNumber(
+            $CurrentUser[$_Vars_GameElements[$ElementID]] +
+            ($elementQueueLevelModifier * -1)
+        );
         $ElementParser['BuildLevel'] = prettyNumber($CurrentUser[$_Vars_GameElements[$ElementID]] + 1);
         $ElementParser['Desc'] = $_Lang['WorldElements_Detailed'][$ElementID]['description_short'];
         $ElementParser['BuildButtonColor'] = 'buildDo_Green';
 
-        if(isset($LevelModifiers[$ElementID]))
+        if ($isElementInQueue)
         {
             $ElementParser['levelmodif']['modColor'] = 'lime';
-            $ElementParser['levelmodif']['modText'] = '+'.prettyNumber($LevelModifiers[$ElementID] * (-1));
+            $ElementParser['levelmodif']['modText'] = '+'.prettyNumber($elementQueueLevelModifier);
             $ElementParser['LevelModifier'] = parsetemplate($TPL['infobox_levelmodif'], $ElementParser['levelmodif']);
             $ElementParser['ElementLevelModif'] = parsetemplate($TPL['list_levelmodif'], $ElementParser['levelmodif']);
             unset($ElementParser['levelmodif']);
@@ -361,7 +348,7 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
                     {
                         $ResMinusColor = 'red';
                         $MinusValue = '('.prettyNumber($UseVar[$Key] - $Value).')';
-                        if($Queue['lenght'] > 0)
+                        if($elementsInQueue > 0)
                         {
                             $ResColor = 'orange';
                         }
@@ -409,7 +396,7 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
         if(IsElementBuyable($CurrentUser, $CurrentPlanet, $ElementID, false) === false)
         {
             $HasResources = false;
-            if($Queue['lenght'] == 0)
+            if($elementsInQueue == 0)
             {
                 $ElementParser['BuildButtonColor'] = 'buildDo_Gray';
                 $HideButton_QuickBuild = true;
@@ -498,16 +485,18 @@ function LaboratoryPage(&$CurrentPlanet, $CurrentUser, $InResearch, $ThePlanet)
         $InfoBoxes[] = parsetemplate($TPL['infobox_body'], $ElementParser);
     }
 
-    if(!empty($LevelModifiers))
-    {
-        foreach($LevelModifiers as $ElementID => $Modifier)
-        {
-            $CurrentUser[$_Vars_GameElements[$ElementID]] += $Modifier;
+    // Restore resources & element levels to previous values
+    foreach ($queueStateDetails['queuedResourcesToUse'] as $resourceKey => $resourceValue) {
+        if (Resources\isPlanetaryResource($resourceKey)) {
+            $CurrentPlanet[$resourceKey] += $resourceValue;
+        } else if (Resources\isUserResource($resourceKey)) {
+            $CurrentUser[$resourceKey] += $resourceValue;
         }
     }
-    $CurrentPlanet['metal'] += (isset($LockResources['metal']) ? $LockResources['metal'] : 0);
-    $CurrentPlanet['crystal'] += (isset($LockResources['crystal']) ? $LockResources['crystal'] : 0);
-    $CurrentPlanet['deuterium'] += (isset($LockResources['deuterium']) ? $LockResources['deuterium'] : 0);
+    foreach ($queueStateDetails['queuedElementLevelModifiers'] as $elementID => $elementLevelModifier) {
+        $elementKey = Elements\getElementKey($elementID);
+        $CurrentUser[$elementKey] -= $elementLevelModifier;
+    }
 
     // Create List
     $ThisRowIndex = 0;

--- a/includes/functions/ResearchBuildingPage.php
+++ b/includes/functions/ResearchBuildingPage.php
@@ -118,7 +118,7 @@ function ResearchBuildingPage(&$CurrentPlanet, $CurrentUser, $ThePlanet) {
 
     $queueStateDetails = Development\Utils\getQueueStateDetails([
         'queue' => [
-            'type' => Development\Utils\QueueType::Technology,
+            'type' => Development\Utils\QueueType::Research,
             'content' => $researchQueue,
         ],
         'user' => $CurrentUser,

--- a/includes/functions/ResearchBuildingPage.php
+++ b/includes/functions/ResearchBuildingPage.php
@@ -1,8 +1,11 @@
 <?php
 
+use UniEngine\Engine\Modules\Development;
 use UniEngine\Engine\Modules\Development\Components\LegacyQueue;
 use UniEngine\Engine\Includes\Helpers\Planets;
 use UniEngine\Engine\Includes\Helpers\Users;
+use UniEngine\Engine\Includes\Helpers\World\Resources;
+use UniEngine\Engine\Includes\Helpers\World\Elements;
 
 function ResearchBuildingPage(&$CurrentPlanet, $CurrentUser, $ThePlanet) {
     global $_EnginePath, $_Lang, $_Vars_ElementCategories, $_SkinPath, $_GameConfig, $_GET;
@@ -115,45 +118,14 @@ function ResearchBuildingPage(&$CurrentPlanet, $CurrentUser, $ThePlanet) {
         }
     ]);
 
-    $queuedElementsResourceLock = [
-        'metal' => 0,
-        'crystal' => 0,
-        'deuterium' => 0
-    ];
-    $queuedElementsLevelModifiers = [];
-
-    $userCopy = $CurrentUser;
-
-    foreach ($researchQueue as $queueElementIdx => $queueElement) {
-        $queueElementID = $queueElement['elementID'];
-        $queueElementKey = _getElementUserKey($queueElementID);
-        $queueElementMode = $queueElement['mode'];
-
-        $isUpgrading = ($queueElementMode == 'build');
-
-        if ($queueElementIdx > 0) {
-            $queueElementCost = GetBuildingPrice(
-                $userCopy,
-                $ResearchPlanet,
-                $queueElementID,
-                true,
-                !$isUpgrading
-            );
-
-            $queuedElementsResourceLock['metal'] += $queueElementCost['metal'];
-            $queuedElementsResourceLock['crystal'] += $queueElementCost['crystal'];
-            $queuedElementsResourceLock['deuterium'] += $queueElementCost['deuterium'];
-        }
-
-        if (!isset($queuedElementsLevelModifiers[$queueElementID])) {
-            $queuedElementsLevelModifiers[$queueElementID] = 0;
-        }
-
-        $levelModifier = ($isUpgrading ? 1 : -1);
-
-        $userCopy[$queueElementKey] += $levelModifier;
-        $queuedElementsLevelModifiers[$queueElementID] += $levelModifier;
-    }
+    $queueStateDetails = Development\Utils\getQueueStateDetails([
+        'queue' => [
+            'type' => Development\Utils\QueueType::Technology,
+            'content' => $researchQueue,
+        ],
+        'user' => $CurrentUser,
+        'planet' => $CurrentPlanet,
+    ]);
 
     $TechRowTPL = gettemplate('buildings_research_row');
 
@@ -162,14 +134,15 @@ function ResearchBuildingPage(&$CurrentPlanet, $CurrentUser, $ThePlanet) {
         $elementKey = _getElementUserKey($elementID);
 
         $currentElementLevel = $CurrentUser[$elementKey];
-        $queuedLevel = (
-            $currentElementLevel +
-            (
-                isset($queuedElementsLevelModifiers[$elementID]) ?
-                $queuedElementsLevelModifiers[$elementID] :
-                0
-            )
+        $isElementInQueue = isset(
+            $queueStateDetails['queuedElementLevelModifiers'][$elementID]
         );
+        $elementQueueLevelModifier = (
+            $isElementInQueue ?
+            $queueStateDetails['queuedElementLevelModifiers'][$elementID] :
+            0
+        );
+        $queuedLevel = ($currentElementLevel + $elementQueueLevelModifier);
 
         $RowParse = $_Lang;
         $RowParse['skinpath'] = $_SkinPath;
@@ -191,11 +164,16 @@ function ResearchBuildingPage(&$CurrentPlanet, $CurrentUser, $ThePlanet) {
             continue;
         }
 
-        if (isset($queuedElementsLevelModifiers[$elementID])) {
-            $CurrentUser[$elementKey] += $queuedElementsLevelModifiers[$elementID];
+        foreach ($queueStateDetails['queuedResourcesToUse'] as $resourceKey => $resourceValue) {
+            if (Resources\isPlanetaryResource($resourceKey)) {
+                $CurrentPlanet[$resourceKey] -= $resourceValue;
+            } else if (Resources\isUserResource($resourceKey)) {
+                $CurrentUser[$resourceKey] -= $resourceValue;
+            }
         }
-        foreach ($queuedElementsResourceLock as $resourceKey => $resourceAmount) {
-            $CurrentPlanet[$resourceKey] -= $resourceAmount;
+        foreach ($queueStateDetails['queuedElementLevelModifiers'] as $queuedElementID => $queuedElementLevelModifier) {
+            $queuedElementKey = Elements\getElementKey($queuedElementID);
+            $CurrentUser[$queuedElementKey] += $queuedElementLevelModifier;
         }
 
         $CanBeDone = IsElementBuyable($CurrentUser, $CurrentPlanet, $elementID, false);
@@ -206,15 +184,20 @@ function ResearchBuildingPage(&$CurrentPlanet, $CurrentUser, $ThePlanet) {
 
         $upgradeNextLevel = 1 + $queuedLevel;
 
-        if (isset($queuedElementsLevelModifiers[$elementID])) {
+        if ($isElementInQueue) {
             $RowParse['AddLevelPrice'] = "<b>[{$_Lang['level']}: {$upgradeNextLevel}]</b><br/>";
         }
 
-        if (isset($queuedElementsLevelModifiers[$elementID])) {
-            $CurrentUser[$elementKey] -= $queuedElementsLevelModifiers[$elementID];
+        foreach ($queueStateDetails['queuedResourcesToUse'] as $resourceKey => $resourceValue) {
+            if (Resources\isPlanetaryResource($resourceKey)) {
+                $CurrentPlanet[$resourceKey] += $resourceValue;
+            } else if (Resources\isUserResource($resourceKey)) {
+                $CurrentUser[$resourceKey] += $resourceValue;
+            }
         }
-        foreach ($queuedElementsResourceLock as $resourceKey => $resourceAmount) {
-            $CurrentPlanet[$resourceKey] += $resourceAmount;
+        foreach ($queueStateDetails['queuedElementLevelModifiers'] as $queuedElementID => $queuedElementLevelModifier) {
+            $queuedElementKey = Elements\getElementKey($queuedElementID);
+            $CurrentUser[$queuedElementKey] -= $queuedElementLevelModifier;
         }
 
         if (isOnVacation($CurrentUser)) {

--- a/includes/functions/ResearchBuildingPage.php
+++ b/includes/functions/ResearchBuildingPage.php
@@ -99,9 +99,7 @@ function ResearchBuildingPage(&$CurrentPlanet, $CurrentUser, $ThePlanet) {
     $isCurrentPlanetResearchPlanet = ($ResearchPlanet['id'] == $CurrentPlanet['id']);
 
     $queueComponent = LegacyQueue\render([
-        'queue' => Planets\Queues\Research\parseQueueString(
-            $ResearchPlanet['techQueue']
-        ),
+        'queue' => $researchQueue,
         'currentTimestamp' => $Now,
 
         'getQueueElementCancellationLinkHref' => function ($queueElement) {

--- a/includes/functions/StructuresBuildingPage.php
+++ b/includes/functions/StructuresBuildingPage.php
@@ -18,7 +18,6 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
     $Now = time();
     $Parse = &$_Lang;
     $ShowElementID = 0;
-    $FieldsModifier = 0;
 
     PlanetResourceUpdate($CurrentUser, $CurrentPlanet, $Now);
 
@@ -79,64 +78,34 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
         }
     ]);
 
+    $queueStateDetails = Development\Utils\getQueueStateDetails([
+        'queue' => [
+            'type' => Development\Utils\QueueType::Planetary,
+            'content' => Planets\Queues\Structures\parseQueueString($CurrentPlanet['buildQueue']),
+        ],
+        'user' => $CurrentUser,
+        'planet' => $CurrentPlanet,
+    ]);
+    $elementsInQueue = $queueStateDetails['queuedElementsCount'];
+    $planetFieldsUsageCounter = 0;
+
+    foreach ($queueStateDetails['queuedResourcesToUse'] as $resourceKey => $resourceValue) {
+        if (Resources\isPlanetaryResource($resourceKey)) {
+            $CurrentPlanet[$resourceKey] -= $resourceValue;
+        } else if (Resources\isUserResource($resourceKey)) {
+            $CurrentUser[$resourceKey] -= $resourceValue;
+        }
+    }
+    foreach ($queueStateDetails['queuedElementLevelModifiers'] as $elementID => $elementLevelModifier) {
+        $elementKey = Elements\getElementKey($elementID);
+        $CurrentPlanet[$elementKey] += $elementLevelModifier;
+        $planetFieldsUsageCounter += $elementLevelModifier;
+    }
+
     $Parse['Create_Queue'] = $queueComponent['componentHTML'];
 
-    // Parse Queue
-    $CurrentQueue = $CurrentPlanet['buildQueue'];
-    if (!empty($CurrentQueue)) {
-        $LockResources['metal'] = 0;
-        $LockResources['crystal'] = 0;
-        $LockResources['deuterium'] = 0;
-
-        $CurrentQueue = explode(';', $CurrentQueue);
-        $QueueIndex = 0;
-
-        foreach ($CurrentQueue as $QueueID => $QueueData) {
-            $QueueData = explode(',', $QueueData);
-            $BuildEndTime = $QueueData[3];
-
-            if ($BuildEndTime < $Now) {
-                continue;
-            }
-
-            $ElementID = $QueueData[0];
-            $ElementMode = $QueueData[4];
-            $ThisForDestroy = ($ElementMode != 'build');
-
-            if ($QueueIndex != 0) {
-                $GetResourcesToLock = GetBuildingPrice($CurrentUser, $CurrentPlanet, $ElementID, true, $ThisForDestroy);
-                $LockResources['metal'] += $GetResourcesToLock['metal'];
-                $LockResources['crystal'] += $GetResourcesToLock['crystal'];
-                $LockResources['deuterium'] += $GetResourcesToLock['deuterium'];
-            }
-
-            if (!isset($LevelModifiers[$ElementID])) {
-                $LevelModifiers[$ElementID] = 0;
-            }
-            if ($ThisForDestroy) {
-                $LevelModifiers[$ElementID] += 1;
-                $CurrentPlanet[$_Vars_GameElements[$ElementID]] -= 1;
-                $FieldsModifier += 2;
-            } else {
-                $LevelModifiers[$ElementID] -= 1;
-                $CurrentPlanet[$_Vars_GameElements[$ElementID]] += 1;
-            }
-
-            $QueueIndex += 1;
-        }
-
-        $CurrentPlanet['metal'] -= (isset($LockResources['metal']) ? $LockResources['metal'] : 0);
-        $CurrentPlanet['crystal'] -= (isset($LockResources['crystal']) ? $LockResources['crystal'] : 0);
-        $CurrentPlanet['deuterium'] -= (isset($LockResources['deuterium']) ? $LockResources['deuterium'] : 0);
-
-        $Queue['lenght'] = $QueueIndex;
-    } else {
-        $Queue['lenght'] = 0;
-    }
-    // End of - Parse Queue
-
     // Parse all available buildings
-    if(($CurrentPlanet['field_current'] + $Queue['lenght'] - $FieldsModifier) < CalculateMaxPlanetFields($CurrentPlanet))
+    if(($CurrentPlanet['field_current'] + $planetFieldsUsageCounter) < CalculateMaxPlanetFields($CurrentPlanet))
     {
         $HasLeftFields = true;
     }
@@ -144,7 +113,7 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
     {
         $HasLeftFields = false;
     }
-    if($Queue['lenght'] < ((isPro($CurrentUser)) ? MAX_BUILDING_QUEUE_SIZE_PRO : MAX_BUILDING_QUEUE_SIZE))
+    if($elementsInQueue < ((isPro($CurrentUser)) ? MAX_BUILDING_QUEUE_SIZE_PRO : MAX_BUILDING_QUEUE_SIZE))
     {
         $CanAddToQueue = true;
     }
@@ -183,7 +152,7 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
         'InfoBox_BuildTime'                => $_Lang['InfoBox_BuildTime'],
     );
 
-    $hasElementsInQueue = ($Queue['lenght'] > 0);
+    $hasElementsInQueue = ($elementsInQueue > 0);
     $resourceLabels = [
         'metal'         => $_Lang['Metal'],
         'crystal'       => $_Lang['Crystal'],
@@ -203,6 +172,15 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
 
             $CurrentLevel = $CurrentPlanet[$_Vars_GameElements[$ElementID]];
             $NextLevel = $CurrentPlanet[$_Vars_GameElements[$ElementID]] + 1;
+            $isElementInQueue = isset(
+                $queueStateDetails['queuedElementLevelModifiers'][$ElementID]
+            );
+            $elementQueueLevelModifier = (
+                $isElementInQueue ?
+                $queueStateDetails['queuedElementLevelModifiers'][$ElementID] :
+                0
+            );
+
             $MaxLevelReached = false;
             $TechLevelOK = false;
             $HasResources = true;
@@ -215,21 +193,24 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
             $ElementParser['ElementName'] = $_Lang['tech'][$ElementID];
             $ElementParser['ElementID'] = $ElementID;
             $ElementParser['ElementLevel'] = prettyNumber($CurrentPlanet[$_Vars_GameElements[$ElementID]]);
-            $ElementParser['ElementRealLevel'] = prettyNumber($CurrentPlanet[$_Vars_GameElements[$ElementID]] + (isset($LevelModifiers[$ElementID]) ? $LevelModifiers[$ElementID] : 0));
+            $ElementParser['ElementRealLevel'] = prettyNumber(
+                $CurrentPlanet[$_Vars_GameElements[$ElementID]] +
+                ($elementQueueLevelModifier * -1)
+            );
             $ElementParser['BuildLevel'] = prettyNumber($CurrentPlanet[$_Vars_GameElements[$ElementID]] + 1);
             $ElementParser['DestroyLevel'] = prettyNumber($CurrentPlanet[$_Vars_GameElements[$ElementID]] - 1);
             $ElementParser['Desc'] = $_Lang['WorldElements_Detailed'][$ElementID]['description_short'];
             $ElementParser['BuildButtonColor'] = 'buildDo_Green';
             $ElementParser['DestroyButtonColor'] = 'buildDo_Red';
 
-            if(isset($LevelModifiers[$ElementID]))
+            if($isElementInQueue)
             {
-                if($LevelModifiers[$ElementID] > 0)
+                if($elementQueueLevelModifier < 0)
                 {
                     $ElementParser['levelmodif']['modColor'] = 'red';
-                    $ElementParser['levelmodif']['modText'] = prettyNumber($LevelModifiers[$ElementID] * (-1));
+                    $ElementParser['levelmodif']['modText'] = prettyNumber($elementQueueLevelModifier);
                 }
-                else if($LevelModifiers[$ElementID] == 0)
+                else if($elementQueueLevelModifier == 0)
                 {
                     $ElementParser['levelmodif']['modColor'] = 'orange';
                     $ElementParser['levelmodif']['modText'] = '0';
@@ -237,7 +218,7 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
                 else
                 {
                     $ElementParser['levelmodif']['modColor'] = 'lime';
-                    $ElementParser['levelmodif']['modText'] = '+'.prettyNumber($LevelModifiers[$ElementID] * (-1));
+                    $ElementParser['levelmodif']['modText'] = '+'.prettyNumber($elementQueueLevelModifier);
                 }
                 $ElementParser['LevelModifier'] = parsetemplate($TPL['infobox_levelmodif'], $ElementParser['levelmodif']);
                 $ElementParser['ElementLevelModif'] = parsetemplate($TPL['list_levelmodif'], $ElementParser['levelmodif']);
@@ -267,7 +248,7 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
                         {
                             $ResMinusColor = 'red';
                             $MinusValue = '('.prettyNumber($UseVar[$Key] - $Value).')';
-                            if($Queue['lenght'] > 0)
+                            if($elementsInQueue > 0)
                             {
                                 $ResColor = 'orange';
                             }
@@ -323,7 +304,7 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
             if(IsElementBuyable($CurrentUser, $CurrentPlanet, $ElementID, false) === false)
             {
                 $HasResources = false;
-                if($Queue['lenght'] == 0)
+                if($elementsInQueue == 0)
                 {
                     $ElementParser['BuildButtonColor'] = 'buildDo_Gray';
                     $HideButton_QuickBuild = true;
@@ -335,7 +316,7 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
             }
             if(IsElementBuyable($CurrentUser, $CurrentPlanet, $ElementID, true) === false)
             {
-                if($Queue['lenght'] == 0)
+                if($elementsInQueue == 0)
                 {
                     $ElementParser['DestroyButtonColor'] = 'destroyDo_Gray';
                 }
@@ -521,16 +502,17 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
         }
     }
 
-    if(!empty($LevelModifiers))
-    {
-        foreach($LevelModifiers as $ElementID => $Modifier)
-        {
-            $CurrentPlanet[$_Vars_GameElements[$ElementID]] += $Modifier;
+    foreach ($queueStateDetails['queuedResourcesToUse'] as $resourceKey => $resourceValue) {
+        if (Resources\isPlanetaryResource($resourceKey)) {
+            $CurrentPlanet[$resourceKey] += $resourceValue;
+        } else if (Resources\isUserResource($resourceKey)) {
+            $CurrentUser[$resourceKey] += $resourceValue;
         }
     }
-    $CurrentPlanet['metal'] += (isset($LockResources['metal']) ? $LockResources['metal'] : 0);
-    $CurrentPlanet['crystal'] += (isset($LockResources['crystal']) ? $LockResources['crystal'] : 0);
-    $CurrentPlanet['deuterium'] += (isset($LockResources['deuterium']) ? $LockResources['deuterium'] : 0);
+    foreach ($queueStateDetails['queuedElementLevelModifiers'] as $elementID => $elementLevelModifier) {
+        $elementKey = Elements\getElementKey($elementID);
+        $CurrentPlanet[$elementKey] -= $elementLevelModifier;
+    }
 
     // Create Structures List
     $ThisRowIndex = 0;

--- a/includes/functions/StructuresBuildingPage.php
+++ b/includes/functions/StructuresBuildingPage.php
@@ -54,10 +54,13 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
         $ShowElementID = $cmdResult['payload']['elementID'];
     }
     // End of - Handle Commands
+    $structuresQueueContent = Planets\Queues\Structures\parseQueueString(
+        $CurrentPlanet['buildQueue']
+    );
 
     $queueComponent = ModernQueue\render([
         'planet' => &$CurrentPlanet,
-        'queue' => Planets\Queues\Structures\parseQueueString($CurrentPlanet['buildQueue']),
+        'queue' => $structuresQueueContent,
         'queueMaxLength' => Users\getMaxStructuresQueueLength($CurrentUser),
         'timestamp' => $Now,
         'infoComponents' => [],
@@ -81,7 +84,7 @@ function StructuresBuildingPage(&$CurrentPlanet, $CurrentUser)
     $queueStateDetails = Development\Utils\getQueueStateDetails([
         'queue' => [
             'type' => Development\Utils\QueueType::Planetary,
-            'content' => Planets\Queues\Structures\parseQueueString($CurrentPlanet['buildQueue']),
+            'content' => $structuresQueueContent,
         ],
         'user' => $CurrentUser,
         'planet' => $CurrentPlanet,

--- a/includes/helpers/world/elements.common.functions.php
+++ b/includes/helpers/world/elements.common.functions.php
@@ -114,6 +114,29 @@ function isDowngradeable($elementID) {
     );
 }
 
+function isPlanetaryElement($elementID) {
+    return (
+        isStructure($elementID) ||
+        isConstructibleInHangar($elementID)
+    );
+}
+
+function isUserElement($elementID) {
+    return isTechnology($elementID);
+}
+
+function getElementKey($elementID) {
+    if (isPlanetaryElement($elementID)) {
+        return _getElementPlanetKey($elementID);
+    }
+
+    if (isUserElement($elementID)) {
+        return _getElementUserKey($elementID);
+    }
+
+    throw new Exceptions\UniEngineException("Cannot get element's key of an element with ID '{$elementID}'");
+}
+
 function getElementMaxUpgradeLevel($elementID) {
     global $_Vars_MaxElementLevel;
 

--- a/modules/development/_includes.php
+++ b/modules/development/_includes.php
@@ -6,6 +6,8 @@ call_user_func(function () {
 
     $includePath = $_EnginePath . 'modules/development/';
 
+    include($includePath . './utils/queue.utils.php');
+
     include($includePath . './input/research.userCommands.php');
     include($includePath . './input/structures.userCommands.php');
 

--- a/modules/development/utils/index.php
+++ b/modules/development/utils/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/development/utils/queue.utils.php
+++ b/modules/development/utils/queue.utils.php
@@ -35,6 +35,14 @@ function getQueueStateDetails ($props) {
     $queue = $props['queue']['content'];
     $queueType = $props['queue']['type'];
 
+    if ($queueType === QueueType::Planetary) {
+        $objectToModifyLevels = &$planet;
+    } else if ($queueType === QueueType::Research) {
+        $objectToModifyLevels = &$user;
+    } else {
+        throw new Exceptions\UniEngineException("Invalid queue type ('{$queueType}')");
+    }
+
     $resourceKeys = Resources\getKnownSpendableResourceKeys();
     $queuedResourcesToUse = array_map(
         function () { return 0; },
@@ -44,14 +52,6 @@ function getQueueStateDetails ($props) {
     $queuedElementLevelModifiers = [];
 
     $objectToModifyLevels = [];
-
-    if ($queueType === QueueType::Planetary) {
-        $objectToModifyLevels = &$planet;
-    } else if ($queueType === QueueType::Research) {
-        $objectToModifyLevels = &$user;
-    } else {
-        throw new Exceptions\UniEngineException("Invalid queue type ('{$queueType}')");
-    }
 
     foreach ($queue as $queueIdx => $queueElement) {
         $elementID = $queueElement['elementID'];

--- a/modules/development/utils/queue.utils.php
+++ b/modules/development/utils/queue.utils.php
@@ -8,7 +8,7 @@ use UniEngine\Engine\Includes\Helpers\World\Elements;
 
 abstract class QueueType {
     const Planetary = 'QueueType::Planetary';
-    const Technology = 'QueueType::Technology';
+    const Research = 'QueueType::Research';
 }
 
 //  Arguments
@@ -47,7 +47,7 @@ function getQueueStateDetails ($props) {
 
     if ($queueType === QueueType::Planetary) {
         $objectToModifyLevels = &$planet;
-    } else if ($queueType === QueueType::Technology) {
+    } else if ($queueType === QueueType::Research) {
         $objectToModifyLevels = &$user;
     } else {
         throw new Exceptions\UniEngineException("Invalid queue type ('{$queueType}')");

--- a/modules/development/utils/queue.utils.php
+++ b/modules/development/utils/queue.utils.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Development\Utils;
+
+use UniEngine\Engine\Common\Exceptions;
+use UniEngine\Engine\Includes\Helpers\World\Resources;
+use UniEngine\Engine\Includes\Helpers\World\Elements;
+
+abstract class QueueType {
+    const Planetary = 'QueueType::Planetary';
+    const Technology = 'QueueType::Technology';
+}
+
+//  Arguments
+//      - $props (Object)
+//          - queue (Object)
+//              - type (QueueType)
+//              - content (Array<QueueElement>)
+//          - user (Object)
+//          - planet (Object)
+//
+//  Returns: Object
+//      - queuedResourcesToUse (Object<resourceKey: string, value: number>)
+//          How much resources are yet to be consumed by all of the queued
+//          elements. Does not count the first element of the queue, because these
+//          resources have already been "consumed".
+//      - queuedElementLevelModifiers (Object<elementID: string, levelModifier: number>)
+//          Difference between current state and the future state of queued element levels.
+//      - queuedElementsCount (Number)
+//          How many elements are there in queue.
+//
+function getQueueStateDetails ($props) {
+    $planet = &$props['planet'];
+    $user = &$props['user'];
+    $queue = $props['queue']['content'];
+    $queueType = $props['queue']['type'];
+
+    $resourceKeys = Resources\getKnownSpendableResourceKeys();
+    $queuedResourcesToUse = array_map(
+        function () { return 0; },
+        array_flip($resourceKeys)
+    );
+
+    $queuedElementLevelModifiers = [];
+
+    $objectToModifyLevels = [];
+
+    if ($queueType === QueueType::Planetary) {
+        $objectToModifyLevels = &$planet;
+    } else if ($queueType === QueueType::Technology) {
+        $objectToModifyLevels = &$user;
+    } else {
+        throw new Exceptions\UniEngineException("Invalid queue type ('{$queueType}')");
+    }
+
+    foreach ($queue as $queueIdx => $queueElement) {
+        $elementID = $queueElement['elementID'];
+        $elementMode = $queueElement['mode'];
+        $isFirstQueueElement = ($queueIdx === 0);
+        $isUpgrade = ($elementMode === 'build');
+        $thisLevelModifier = ($isUpgrade ? 1 : -1);
+
+        $elementKey = Elements\getElementKey($elementID);
+
+        if (!isset($queuedElementLevelModifiers[$elementID])) {
+            $queuedElementLevelModifiers[$elementID] = 0;
+        }
+
+        // Store the current level modifier before updating it in the accumulator
+        $elementCurrentLevelModifier = $queuedElementLevelModifiers[$elementID];
+
+        $queuedElementLevelModifiers[$elementID] += $thisLevelModifier;
+
+        if ($isFirstQueueElement) {
+            continue;
+        }
+
+        $objectToModifyLevels[$elementKey] += $elementCurrentLevelModifier;
+
+        $elementPurchaseCost = Elements\calculatePurchaseCost(
+            $elementID,
+            Elements\getElementState($elementID, $planet, $user),
+            [
+                'purchaseMode' => (
+                    $isUpgrade ?
+                    Elements\PurchaseMode::Upgrade :
+                    Elements\PurchaseMode::Downgrade
+                )
+            ]
+        );
+
+        foreach ($elementPurchaseCost as $costKey => $costValue) {
+            if (!Resources\isSpendableResource($costKey)) {
+                continue;
+            }
+
+            $queuedResourcesToUse[$costKey] += $costValue;
+        }
+
+        $objectToModifyLevels[$elementKey] -= $elementCurrentLevelModifier;
+    }
+
+    return [
+        'queuedResourcesToUse' => $queuedResourcesToUse,
+        'queuedElementLevelModifiers' => $queuedElementLevelModifiers,
+        'queuedElementsCount' => count($queue),
+    ];
+}
+
+?>


### PR DESCRIPTION
Part of #63 

Changelog:
- [x] Create queue state details getter utility
- [x] Use new utility on:
    - [x] Grid Structures page
    - [x] Grid Tech page
    - [x] List Structures page
    - [x] List Tech page
- [x] Allow to schedule upgrades when queued element unlocks requirements [not part of #61]
    - [x] List Tech page
    - [x] List Strcutures page