### PR TITLE
Refactor fleet missions' code | Part 02 | Resources loss & debris calculation

### DIFF
--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -881,61 +881,35 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
             }
         }
 
-        // Calculate Debris & Looses - Init
-        $DebrisFactor_Fleet = $_GameConfig['Fleet_Cdr'] / 100;
-        $DebrisFactor_Defense = $_GameConfig['Defs_Cdr'] / 100;
+        // Calculate Debris & Looses
+        $debrisRecoveryPercentages = [
+            'ships' => ($_GameConfig['Fleet_Cdr'] / 100),
+            'defenses' => ($_GameConfig['Defs_Cdr'] / 100),
+        ];
 
-        // Calculate looses - attacker
-        if(!empty($AtkLost))
-        {
-            $DebrisMetalAtk = 0;
-            $DebrisCrystalAtk = 0;
-            foreach($AtkLost as $ID => $Count)
-            {
-                if(in_array($ID, $_Vars_ElementCategories['fleet']))
-                {
-                    if($DebrisFactor_Fleet > 0)
-                    {
-                        $DebrisMetalAtk += floor($_Vars_Prices[$ID]['metal'] * $Count * $DebrisFactor_Fleet);
-                        $DebrisCrystalAtk += floor($_Vars_Prices[$ID]['crystal'] * $Count * $DebrisFactor_Fleet);
-                    }
-                    $RealDebrisMetalAtk += floor($_Vars_Prices[$ID]['metal'] * $Count);
-                    $RealDebrisCrystalAtk += floor($_Vars_Prices[$ID]['crystal'] * $Count);
-                    $RealDebrisDeuteriumAtk += floor($_Vars_Prices[$ID]['deuterium'] * $Count);
-                }
-            }
-            $TotalLostMetal = $DebrisMetalAtk;
-            $TotalLostCrystal = $DebrisCrystalAtk;
-        }
+        $attackersResourceLosses = Flights\Utils\Calculations\calculateResourcesLoss([
+            'unitsLost' => $AtkLost,
+            'debrisRecoveryPercentages' => $debrisRecoveryPercentages,
+        ]);
 
-        // Calculate looses - defender
-        if(!empty($DefLost))
-        {
-            foreach($DefLost as $ID => $Count)
-            {
-                if(in_array($ID, $_Vars_ElementCategories['fleet']))
-                {
-                    if($DebrisFactor_Fleet > 0)
-                    {
-                        $DebrisMetalDef += floor($_Vars_Prices[$ID]['metal'] * $Count * $DebrisFactor_Fleet);
-                        $DebrisCrystalDef += floor($_Vars_Prices[$ID]['crystal'] * $Count * $DebrisFactor_Fleet);
-                    }
-                }
-                elseif(in_array($ID, $_Vars_ElementCategories['defense']))
-                {
-                    if($DebrisFactor_Defense > 0)
-                    {
-                        $DebrisMetalDef += floor($_Vars_Prices[$ID]['metal'] * $Count * $DebrisFactor_Defense);
-                        $DebrisCrystalDef += floor($_Vars_Prices[$ID]['crystal'] * $Count * $DebrisFactor_Defense);
-                    }
-                }
-                $RealDebrisMetalDef += floor($_Vars_Prices[$ID]['metal'] * $Count);
-                $RealDebrisCrystalDef += floor($_Vars_Prices[$ID]['crystal'] * $Count);
-                $RealDebrisDeuteriumDef += floor($_Vars_Prices[$ID]['deuterium'] * $Count);
-            }
-            $TotalLostMetal += $DebrisMetalDef;
-            $TotalLostCrystal += $DebrisCrystalDef;
-        }
+        $RealDebrisMetalAtk += $attackersResourceLosses['realLoss']['metal'];
+        $RealDebrisCrystalAtk += $attackersResourceLosses['realLoss']['crystal'];
+        $RealDebrisDeuteriumAtk += $attackersResourceLosses['realLoss']['deuterium'];
+        $TotalLostMetal += $attackersResourceLosses['recoverableLoss']['metal'];
+        $TotalLostCrystal += $attackersResourceLosses['recoverableLoss']['crystal'];
+
+        $defendersResourceLosses = Flights\Utils\Calculations\calculateResourcesLoss([
+            'unitsLost' => $DefLost,
+            'debrisRecoveryPercentages' => $debrisRecoveryPercentages,
+        ]);
+
+        $RealDebrisMetalDef += $defendersResourceLosses['realLoss']['metal'];
+        $RealDebrisCrystalDef += $defendersResourceLosses['realLoss']['crystal'];
+        $RealDebrisDeuteriumDef += $defendersResourceLosses['realLoss']['deuterium'];
+        $TotalLostMetal += $defendersResourceLosses['recoverableLoss']['metal'];
+        $TotalLostCrystal += $defendersResourceLosses['recoverableLoss']['crystal'];
+        $DebrisMetalDef += $defendersResourceLosses['recoverableLoss']['metal'];
+        $DebrisCrystalDef += $defendersResourceLosses['recoverableLoss']['crystal'];
 
         // Delete fleets (if necessary)
         if(!empty($DeleteFleet))

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -950,61 +950,35 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
             }
         }
 
-        // Calculate Debris & Looses - Init
-        $DebrisFactor_Fleet = $_GameConfig['Fleet_Cdr'] / 100;
-        $DebrisFactor_Defense = $_GameConfig['Defs_Cdr'] / 100;
+        // Calculate Debris & Looses
+        $debrisRecoveryPercentages = [
+            'ships' => ($_GameConfig['Fleet_Cdr'] / 100),
+            'defenses' => ($_GameConfig['Defs_Cdr'] / 100),
+        ];
 
-        // Calculate looses - attacker
-        if(!empty($AtkLost))
-        {
-            $DebrisMetalAtk = 0;
-            $DebrisCrystalAtk = 0;
-            foreach($AtkLost as $ID => $Count)
-            {
-                if(in_array($ID, $_Vars_ElementCategories['fleet']))
-                {
-                    if($DebrisFactor_Fleet > 0)
-                    {
-                        $DebrisMetalAtk += floor($_Vars_Prices[$ID]['metal'] * $Count * $DebrisFactor_Fleet);
-                        $DebrisCrystalAtk += floor($_Vars_Prices[$ID]['crystal'] * $Count * $DebrisFactor_Fleet);
-                    }
-                    $RealDebrisMetalAtk += floor($_Vars_Prices[$ID]['metal'] * $Count);
-                    $RealDebrisCrystalAtk += floor($_Vars_Prices[$ID]['crystal'] * $Count);
-                    $RealDebrisDeuteriumAtk += floor($_Vars_Prices[$ID]['deuterium'] * $Count);
-                }
-            }
-            $TotalLostMetal = $DebrisMetalAtk;
-            $TotalLostCrystal = $DebrisCrystalAtk;
-        }
+        $attackersResourceLosses = Flights\Utils\Calculations\calculateResourcesLoss([
+            'unitsLost' => $AtkLost,
+            'debrisRecoveryPercentages' => $debrisRecoveryPercentages,
+        ]);
 
-        // Calculate looses - defender
-        if(!empty($DefLost))
-        {
-            foreach($DefLost as $ID => $Count)
-            {
-                if(in_array($ID, $_Vars_ElementCategories['fleet']))
-                {
-                    if($DebrisFactor_Fleet > 0)
-                    {
-                        $DebrisMetalDef += floor($_Vars_Prices[$ID]['metal'] * $Count * $DebrisFactor_Fleet);
-                        $DebrisCrystalDef += floor($_Vars_Prices[$ID]['crystal'] * $Count * $DebrisFactor_Fleet);
-                    }
-                }
-                elseif(in_array($ID, $_Vars_ElementCategories['defense']))
-                {
-                    if($DebrisFactor_Defense > 0)
-                    {
-                        $DebrisMetalDef += floor($_Vars_Prices[$ID]['metal'] * $Count * $DebrisFactor_Defense);
-                        $DebrisCrystalDef += floor($_Vars_Prices[$ID]['crystal'] * $Count * $DebrisFactor_Defense);
-                    }
-                }
-                $RealDebrisMetalDef += floor($_Vars_Prices[$ID]['metal'] * $Count);
-                $RealDebrisCrystalDef += floor($_Vars_Prices[$ID]['crystal'] * $Count);
-                $RealDebrisDeuteriumDef += floor($_Vars_Prices[$ID]['deuterium'] * $Count);
-            }
-            $TotalLostMetal += $DebrisMetalDef;
-            $TotalLostCrystal += $DebrisCrystalDef;
-        }
+        $RealDebrisMetalAtk += $attackersResourceLosses['realLoss']['metal'];
+        $RealDebrisCrystalAtk += $attackersResourceLosses['realLoss']['crystal'];
+        $RealDebrisDeuteriumAtk += $attackersResourceLosses['realLoss']['deuterium'];
+        $TotalLostMetal += $attackersResourceLosses['recoverableLoss']['metal'];
+        $TotalLostCrystal += $attackersResourceLosses['recoverableLoss']['crystal'];
+
+        $defendersResourceLosses = Flights\Utils\Calculations\calculateResourcesLoss([
+            'unitsLost' => $DefLost,
+            'debrisRecoveryPercentages' => $debrisRecoveryPercentages,
+        ]);
+
+        $RealDebrisMetalDef += $defendersResourceLosses['realLoss']['metal'];
+        $RealDebrisCrystalDef += $defendersResourceLosses['realLoss']['crystal'];
+        $RealDebrisDeuteriumDef += $defendersResourceLosses['realLoss']['deuterium'];
+        $TotalLostMetal += $defendersResourceLosses['recoverableLoss']['metal'];
+        $TotalLostCrystal += $defendersResourceLosses['recoverableLoss']['crystal'];
+        $DebrisMetalDef += $defendersResourceLosses['recoverableLoss']['metal'];
+        $DebrisCrystalDef += $defendersResourceLosses['recoverableLoss']['crystal'];
 
         // Delete fleets (if necessary)
         if(!empty($DeleteFleet))

--- a/includes/helpers/world/resources.functions.php
+++ b/includes/helpers/world/resources.functions.php
@@ -36,6 +36,13 @@ function getKnownPillagableResourceKeys() {
     ];
 }
 
+function getKnownDebrisRecoverableResourceKeys() {
+    return [
+        'metal',
+        'crystal',
+    ];
+}
+
 function isResource($resourceKey) {
     return (
         isPlanetaryResource($resourceKey) ||

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -6,6 +6,7 @@ call_user_func(function () {
 
     $includePath = $_EnginePath . 'modules/flights/';
 
+    include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
     include($includePath . './utils/missions.utils.php');
 
 });

--- a/modules/flights/utils/calculations/calculateResourcesLoss.utils.UETest.php
+++ b/modules/flights/utils/calculations/calculateResourcesLoss.utils.UETest.php
@@ -1,0 +1,158 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+$_EnginePath = './';
+
+define('INSIDE', true);
+require_once $_EnginePath . 'common/_includes.php';
+require_once $_EnginePath . 'includes/vars.php';
+require_once $_EnginePath . 'includes/helpers/_includes.php';
+require_once $_EnginePath . 'modules/flights/_includes.php';
+
+use UniEngine\Engine\Modules\Flights\Utils\Calculations;
+
+
+/**
+ * @group UniEngineTest
+ */
+class CalculateResourcesLossTestCase extends TestCase {
+    /**
+     * @test
+     */
+    public function itShouldHandleEmptyLossesArray() {
+        $params = [
+            'unitsLost' => [],
+            'debrisRecoveryPercentages' => [
+                'ships' => 0.5,
+                'defenses' => 0.5,
+            ],
+        ];
+
+        $result = Calculations\calculateResourcesLoss($params);
+
+        $this->assertEquals(
+            [
+                'realLoss' => [
+                    'metal' => 0,
+                    'crystal' => 0,
+                    'deuterium' => 0,
+                    'darkEnergy' => 0,
+                ],
+                'recoverableLoss' => [
+                    'metal' => 0,
+                    'crystal' => 0,
+                ],
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldProperlyCalculateShipsLosses() {
+        $params = [
+            'unitsLost' => [
+                202 => 10,
+                203 => 1,
+                206 => 1,
+            ],
+            'debrisRecoveryPercentages' => [
+                'ships' => 0.1,
+                'defenses' => 0.1,
+            ],
+        ];
+
+        $result = Calculations\calculateResourcesLoss($params);
+
+        $this->assertEquals(
+            [
+                'realLoss' => [
+                    'metal' => 46000,
+                    'crystal' => 33000,
+                    'deuterium' => 2000,
+                    'darkEnergy' => 0,
+                ],
+                'recoverableLoss' => [
+                    'metal' => 46000 * 0.1,
+                    'crystal' => 33000 * 0.1,
+                ],
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldProperlyCalculateDefensesLosses() {
+        $params = [
+            'unitsLost' => [
+                401 => 10,
+                402 => 1,
+                404 => 1,
+            ],
+            'debrisRecoveryPercentages' => [
+                'ships' => 0.1,
+                'defenses' => 0.1,
+            ],
+        ];
+
+        $result = Calculations\calculateResourcesLoss($params);
+
+        $this->assertEquals(
+            [
+                'realLoss' => [
+                    'metal' => 41500,
+                    'crystal' => 15500,
+                    'deuterium' => 2000,
+                    'darkEnergy' => 0,
+                ],
+                'recoverableLoss' => [
+                    'metal' => 41500 * 0.1,
+                    'crystal' => 15500 * 0.1,
+                ],
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldProperlyCalculateMixedLosses() {
+        $params = [
+            'unitsLost' => [
+                202 => 10,
+                203 => 1,
+                206 => 1,
+                401 => 10,
+                402 => 1,
+                404 => 1,
+            ],
+            'debrisRecoveryPercentages' => [
+                'ships' => 0.1,
+                'defenses' => 0.2,
+            ],
+        ];
+
+        $result = Calculations\calculateResourcesLoss($params);
+
+        $this->assertEquals(
+            [
+                'realLoss' => [
+                    'metal' => 46000 + 41500,
+                    'crystal' => 33000 + 15500,
+                    'deuterium' => 2000 + 2000,
+                    'darkEnergy' => 0,
+                ],
+                'recoverableLoss' => [
+                    'metal' => (46000 * 0.1) + (41500 * 0.2),
+                    'crystal' => (33000 * 0.1) + (15500 * 0.2),
+                ],
+            ],
+            $result
+        );
+    }
+}

--- a/modules/flights/utils/calculations/calculateResourcesLoss.utils.php
+++ b/modules/flights/utils/calculations/calculateResourcesLoss.utils.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Calculations;
+
+use UniEngine\Engine\Includes\Helpers\World\Resources;
+use UniEngine\Engine\Includes\Helpers\World\Elements;
+
+/**
+ *
+ * @param array $params
+ * @param array $params['unitsLost']
+ * @param array $params['debrisRecoveryPercentages']
+ * @param number $params['debrisRecoveryPercentages']['ships']
+ * @param number $params['debrisRecoveryPercentages']['defenses']
+ */
+function calculateResourcesLoss($params) {
+    global $_Vars_Prices;
+
+    $unitsLost = (
+        !empty($params['unitsLost']) ?
+        $params['unitsLost'] :
+        []
+    );
+    $debrisRecoveryPercentages = $params['debrisRecoveryPercentages'];
+
+    $spendableResourceKeys = Resources\getKnownSpendableResourceKeys();
+    $recoverableResourceKeys = Resources\getKnownDebrisRecoverableResourceKeys();
+
+    $realLossAccumulator = [];
+    $recoverableLossAccumulator = [];
+
+    foreach ($spendableResourceKeys as $resourceKey) {
+        $realLossAccumulator[$resourceKey] = 0;
+    }
+    foreach ($recoverableResourceKeys as $resourceKey) {
+        $recoverableLossAccumulator[$resourceKey] = 0;
+    }
+
+    foreach ($unitsLost as $unitID => $unitAmount) {
+        if (
+            !Elements\isShip($unitID) &&
+            !Elements\isDefenseSystem($unitID)
+        ) {
+            continue;
+        }
+
+        $unitTypeRecoveryFactor = (
+            Elements\isShip($unitID) ?
+            $debrisRecoveryPercentages['ships'] :
+            $debrisRecoveryPercentages['defenses']
+        );
+
+        foreach ($spendableResourceKeys as $resourceKey) {
+            if (!isset($_Vars_Prices[$unitID][$resourceKey])) {
+                continue;
+            }
+
+            $unitsRealResourceLoss = ($_Vars_Prices[$unitID][$resourceKey] * $unitAmount);
+
+            $realLossAccumulator[$resourceKey] += floor($unitsRealResourceLoss);
+
+            if (in_array($resourceKey, $recoverableResourceKeys)) {
+                $recoverableLossAccumulator[$resourceKey] += floor(
+                    $unitsRealResourceLoss *
+                    $unitTypeRecoveryFactor
+                );
+            }
+        }
+    }
+
+    return [
+        'realLoss' => $realLossAccumulator,
+        'recoverableLoss' => $recoverableLossAccumulator,
+    ];
+}
+
+?>

--- a/modules/flights/utils/calculations/index.php
+++ b/modules/flights/utils/calculations/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>


### PR DESCRIPTION
## Summary:

Currently there are three places with resources loss and debris calculation code duplicated. All of them should use a shared function to calculate these values.
## Changelog:

- [x] Extract resources loss & debris calculating function into its separate file
    - [x] Rewrite it into something easier to understand
    - [x] Write tests
- [x] Use the new calculation function in attacks handling functions:
    - [x] Regular attack
    - [x] Group attack (ACS)
    - [x] Moon destruction

## Related issues or PRs:

- #91 
