### PR TITLE
Refactor fleet missions' code | Part 02 | Galaxy debris update

### DIFF
--- a/includes/functions/FlyingFleetHandler.php
+++ b/includes/functions/FlyingFleetHandler.php
@@ -827,11 +827,20 @@ function FlyingFleetHandler(&$planet, $IncludeFleetsFromEndIDs = array())
             if(!empty($_FleetCache['galaxy']) AND $_FleetCache['updated']['galaxy'] === true)
             {
                 $TempArray = array();
-                foreach($_FleetCache['galaxy'] as $ThisID => $ThisData)
-                {
-                    if($ThisData['updated'] === true)
-                    {
-                        $TempArray[] = "({$ThisID}, {$ThisData['metal']}, {$ThisData['crystal']})";
+                foreach ($_FleetCache['galaxy'] as $ThisID => $ThisData) {
+                    if ($ThisData['updated'] === true) {
+                        $entryMetalValue = (
+                            $ThisData['metal'] > 0 ?
+                            $ThisData['metal'] :
+                            '0'
+                        );
+                        $entryCrystalValue = (
+                            $ThisData['crystal'] > 0 ?
+                            $ThisData['crystal'] :
+                            '0'
+                        );
+
+                        $TempArray[] = "({$ThisID}, {$entryMetalValue}, {$entryCrystalValue})";
                     }
                 }
                 if(!empty($TempArray))

--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -806,50 +806,21 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
         }
 
         // Create debris field on the orbit
-        if($TotalLostMetal > 0 || $TotalLostCrystal > 0)
-        {
-            if($TotalLostCrystal == 0)
-            {
+        if ($TotalLostMetal > 0 || $TotalLostCrystal > 0) {
+            Flights\Utils\FleetCache\updateGalaxyDebris([
+                'debris' => [
+                    'metal' => $TotalLostMetal,
+                    'crystal' => $TotalLostCrystal,
+                ],
+                'targetPlanet' => $TargetPlanet,
+                'fleetCache' => &$_FleetCache,
+            ]);
+
+            if ($TotalLostCrystal == 0) {
                 $TotalLostCrystal = '0';
             }
-            if($TotalLostMetal == 0)
-            {
+            if ($TotalLostMetal == 0) {
                 $TotalLostMetal = '0';
-            }
-            if($TargetPlanet['planet_type'] == 1)
-            {
-                $Query_UpdateGalaxy_SearchField = 'id_planet';
-                $CacheKey = 'byPlanet';
-            }
-            else
-            {
-                $Query_UpdateGalaxy_SearchField = 'id_moon';
-                $CacheKey = 'byMoon';
-            }
-
-            if(isset($_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]) && $_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']] > 0)
-            {
-                if(!isset($_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['metal']))
-                {
-                    $_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['metal'] = 0;
-                }
-                if(!isset($_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['crystal']))
-                {
-                    $_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['crystal'] = 0;
-                }
-
-                $_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['metal'] += $TotalLostMetal;
-                $_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['crystal'] += $TotalLostCrystal;
-                $_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['updated'] = true;
-                $_FleetCache['updated']['galaxy'] = true;
-            }
-            else
-            {
-                $Query_UpdateGalaxy = '';
-                $Query_UpdateGalaxy .= "UPDATE {{table}} SET `metal` = `metal` + {$TotalLostMetal}, `crystal` = `crystal` + {$TotalLostCrystal} ";
-                $Query_UpdateGalaxy .= "WHERE `{$Query_UpdateGalaxy_SearchField}` = {$FleetRow['fleet_end_id']} LIMIT 1; ";
-                $Query_UpdateGalaxy .= "-- MISSION ATTACK [Q02][FID: {$FleetRow['fleet_id']}]";
-                doquery($Query_UpdateGalaxy, 'galaxy');
             }
         }
 

--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -815,13 +815,6 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                 'targetPlanet' => $TargetPlanet,
                 'fleetCache' => &$_FleetCache,
             ]);
-
-            if ($TotalLostCrystal == 0) {
-                $TotalLostCrystal = '0';
-            }
-            if ($TotalLostMetal == 0) {
-                $TotalLostMetal = '0';
-            }
         }
 
         // Check if Moon has been created
@@ -1195,7 +1188,7 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
             prettyNumber($RealDebrisMetalAtk + $RealDebrisCrystalAtk + $RealDebrisDeuteriumAtk),
             prettyNumber($RealDebrisCrystalDef + $RealDebrisMetalDef + $RealDebrisDeuteriumDef),
             prettyNumber($StolenMet), prettyNumber($StolenCry), prettyNumber($StolenDeu),
-            prettyNumber(isset($TotalLostMetal) ? $TotalLostMetal : 0), prettyNumber(isset($TotalLostCrystal) ? $TotalLostCrystal : 0),
+            prettyNumber($TotalLostMetal), prettyNumber($TotalLostCrystal),
             $ReportHasHLinkRelative, $ReportHasHLinkReal
         );
         $Message = json_encode($Message);

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -970,40 +970,21 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
         }
 
         // Create debris field on the orbit
-        if($TotalLostMetal > 0 || $TotalLostCrystal > 0)
-        {
-            if($TotalLostCrystal == 0)
-            {
+        if ($TotalLostMetal > 0 || $TotalLostCrystal > 0) {
+            Flights\Utils\FleetCache\updateGalaxyDebris([
+                'debris' => [
+                    'metal' => $TotalLostMetal,
+                    'crystal' => $TotalLostCrystal,
+                ],
+                'targetPlanet' => $TargetPlanet,
+                'fleetCache' => &$_FleetCache,
+            ]);
+
+            if ($TotalLostCrystal == 0) {
                 $TotalLostCrystal = '0';
             }
-            if($TotalLostMetal == 0)
-            {
+            if ($TotalLostMetal == 0) {
                 $TotalLostMetal = '0';
-            }
-
-            if(isset($_FleetCache['galaxyMap']['byMoon'][$FleetRow['fleet_end_id']]) && $_FleetCache['galaxyMap']['byMoon'][$FleetRow['fleet_end_id']] > 0)
-            {
-                if(!isset($_FleetCache['galaxy'][$_FleetCache['galaxyMap']['byMoon'][$FleetRow['fleet_end_id']]]['metal']))
-                {
-                    $_FleetCache['galaxy'][$_FleetCache['galaxyMap']['byMoon'][$FleetRow['fleet_end_id']]]['metal'] = 0;
-                }
-                if(!isset($_FleetCache['galaxy'][$_FleetCache['galaxyMap']['byMoon'][$FleetRow['fleet_end_id']]]['crystal']))
-                {
-                    $_FleetCache['galaxy'][$_FleetCache['galaxyMap']['byMoon'][$FleetRow['fleet_end_id']]]['crystal'] = 0;
-                }
-
-                $_FleetCache['galaxy'][$_FleetCache['galaxyMap']['byMoon'][$FleetRow['fleet_end_id']]]['metal'] += $TotalLostMetal;
-                $_FleetCache['galaxy'][$_FleetCache['galaxyMap']['byMoon'][$FleetRow['fleet_end_id']]]['crystal'] += $TotalLostCrystal;
-                $_FleetCache['galaxy'][$_FleetCache['galaxyMap']['byMoon'][$FleetRow['fleet_end_id']]]['updated'] = true;
-                $_FleetCache['updated']['galaxy'] = true;
-            }
-            else
-            {
-                $Query_UpdateGalaxy = '';
-                $Query_UpdateGalaxy .= "UPDATE {{table}} SET `metal` = `metal` + {$TotalLostMetal}, `crystal` = `crystal` + {$TotalLostCrystal} ";
-                $Query_UpdateGalaxy .= "WHERE `id_moon` = {$FleetRow['fleet_end_id']} LIMIT 1; ";
-                $Query_UpdateGalaxy .= "-- MISSION DESTRUCTION [Q05][FID: {$FleetRow['fleet_id']}]";
-                doquery($Query_UpdateGalaxy, 'galaxy');
             }
         }
 

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -979,13 +979,6 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                 'targetPlanet' => $TargetPlanet,
                 'fleetCache' => &$_FleetCache,
             ]);
-
-            if ($TotalLostCrystal == 0) {
-                $TotalLostCrystal = '0';
-            }
-            if ($TotalLostMetal == 0) {
-                $TotalLostMetal = '0';
-            }
         }
 
         // Check if Moon has been created
@@ -1396,7 +1389,7 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
             ($FleetDestroyedByMoon != true ? prettyNumber($StolenMet) : 0),
             ($FleetDestroyedByMoon != true ? prettyNumber($StolenCry) : 0),
             ($FleetDestroyedByMoon != true ? prettyNumber($StolenDeu) : 0),
-            prettyNumber(isset($TotalLostMetal) ? $TotalLostMetal : 0), prettyNumber(isset($TotalLostCrystal) ? $TotalLostCrystal : 0),
+            prettyNumber($TotalLostMetal), prettyNumber($TotalLostCrystal),
             $ReportHasHLinkRelative, $ReportHasHLinkReal
         );
         $Message = json_encode($Message);

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -1067,50 +1067,21 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
         }
 
         // Create debris field on the orbit
-        if($TotalLostMetal > 0 || $TotalLostCrystal > 0)
-        {
-            if($TotalLostCrystal == 0)
-            {
+        if ($TotalLostMetal > 0 || $TotalLostCrystal > 0) {
+            Flights\Utils\FleetCache\updateGalaxyDebris([
+                'debris' => [
+                    'metal' => $TotalLostMetal,
+                    'crystal' => $TotalLostCrystal,
+                ],
+                'targetPlanet' => $TargetPlanet,
+                'fleetCache' => &$_FleetCache,
+            ]);
+
+            if ($TotalLostCrystal == 0) {
                 $TotalLostCrystal = '0';
             }
-            if($TotalLostMetal == 0)
-            {
+            if ($TotalLostMetal == 0) {
                 $TotalLostMetal = '0';
-            }
-            if($TargetPlanet['planet_type'] == 1)
-            {
-                $Query_UpdateGalaxy_SearchField = 'id_planet';
-                $CacheKey = 'byPlanet';
-            }
-            else
-            {
-                $Query_UpdateGalaxy_SearchField = 'id_moon';
-                $CacheKey = 'byMoon';
-            }
-
-            if(isset($_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]) && $_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']] > 0)
-            {
-                if(!isset($_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['metal']))
-                {
-                    $_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['metal'] = 0;
-                }
-                if(!isset($_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['crystal']))
-                {
-                    $_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['crystal'] = 0;
-                }
-
-                $_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['metal'] += $TotalLostMetal;
-                $_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['crystal'] += $TotalLostCrystal;
-                $_FleetCache['galaxy'][$_FleetCache['galaxyMap'][$CacheKey][$FleetRow['fleet_end_id']]]['updated'] = true;
-                $_FleetCache['updated']['galaxy'] = true;
-            }
-            else
-            {
-                $Query_UpdateGalaxy = '';
-                $Query_UpdateGalaxy .= "UPDATE {{table}} SET `metal` = `metal` + {$TotalLostMetal}, `crystal` = `crystal` + {$TotalLostCrystal} ";
-                $Query_UpdateGalaxy .= "WHERE `{$Query_UpdateGalaxy_SearchField}` = {$FleetRow['fleet_end_id']} LIMIT 1; ";
-                $Query_UpdateGalaxy .= "-- MISSION GROUP_ATTACK [Q02][FID: {$FleetRow['fleet_id']}]";
-                doquery($Query_UpdateGalaxy, 'galaxy');
             }
         }
 

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -1076,13 +1076,6 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 'targetPlanet' => $TargetPlanet,
                 'fleetCache' => &$_FleetCache,
             ]);
-
-            if ($TotalLostCrystal == 0) {
-                $TotalLostCrystal = '0';
-            }
-            if ($TotalLostMetal == 0) {
-                $TotalLostMetal = '0';
-            }
         }
 
         // Check if Moon has been created
@@ -1603,7 +1596,7 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
             prettyNumber($RealDebrisMetalAtk + $RealDebrisCrystalAtk + $RealDebrisDeuteriumAtk),
             prettyNumber($RealDebrisCrystalDef + $RealDebrisMetalDef + $RealDebrisDeuteriumDef),
             prettyNumber($TotalMetStolen), prettyNumber($TotalCryStolen), prettyNumber($TotalDeuStolen),
-            prettyNumber(isset($TotalLostMetal) ? $TotalLostMetal : 0), prettyNumber(isset($TotalLostCrystal) ? $TotalLostCrystal : 0),
+            prettyNumber($TotalLostMetal), prettyNumber($TotalLostCrystal),
             $ReportHasHLinkRelative, $ReportHasHLinkReal
         );
         $Message = json_encode($Message);

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -7,6 +7,7 @@ call_user_func(function () {
     $includePath = $_EnginePath . 'modules/flights/';
 
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
+    include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');
     include($includePath . './utils/missions.utils.php');
 
 });

--- a/modules/flights/utils/fleetCache/index.php
+++ b/modules/flights/utils/fleetCache/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/flights/utils/fleetCache/updateGalaxyDebris.utils.php
+++ b/modules/flights/utils/fleetCache/updateGalaxyDebris.utils.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\FleetCache;
+
+use UniEngine\Engine\Includes\Helpers\World\Resources;
+
+/**
+ * Updates galaxy entry by adding debris.
+ * Either updates the cache, or the DB itself (when no cache entry exists).
+ *
+ * @param array $params
+ * @param array $params['debris']
+ * @param array $params['targetPlanet']
+ * @param ref $params['fleetCache']
+ */
+function updateGalaxyDebris($params) {
+    $cacheUpdateResult = _updateFleetCacheGalaxyDebris($params);
+
+    if (
+        !($cacheUpdateResult['isSuccess']) &&
+        $cacheUpdateResult['hasNoFleetCacheGalaxyMapping']
+    ) {
+        _updateDBEntryGalaxyDebris($params);
+    }
+}
+
+/**
+ * @see updateGalaxyDebris()
+ */
+function _updateFleetCacheGalaxyDebris($params) {
+    $debris = $params['debris'];
+    $targetPlanet = $params['targetPlanet'];
+    $fleetCache = &$params['fleetCache'];
+
+    $targetID = $targetPlanet['id'];
+    $galaxyMapIndexBy = (
+        $targetPlanet['planet_type'] == 1 ?
+        'byPlanet' :
+        'byMoon'
+    );
+
+    if (
+        !isset($fleetCache['galaxyMap'][$galaxyMapIndexBy][$targetID]) ||
+        !($fleetCache['galaxyMap'][$galaxyMapIndexBy][$targetID] > 0)
+    ) {
+        return [
+            'isSuccess' => false,
+            'hasNoFleetCacheGalaxyMapping' => true,
+        ];
+    }
+
+    $galaxyEntryID = $fleetCache['galaxyMap'][$galaxyMapIndexBy][$targetID];
+
+    $fleetCacheGalaxyEntry = &$fleetCache['galaxy'][$galaxyEntryID];
+
+    foreach (Resources\getKnownDebrisRecoverableResourceKeys() as $resourceKey) {
+        if (!isset($fleetCacheGalaxyEntry[$resourceKey])) {
+            $fleetCacheGalaxyEntry[$resourceKey] = 0;
+        }
+        if (!isset($debris[$resourceKey])) {
+            continue;
+        }
+
+        $fleetCacheGalaxyEntry[$resourceKey] += $debris[$resourceKey];
+    }
+
+    $fleetCacheGalaxyEntry['updated'] = true;
+    $fleetCache['updated']['galaxy'] = true;
+
+    return [
+        'isSuccess' => true,
+    ];
+}
+
+/**
+ * @see updateGalaxyDebris()
+ */
+function _updateDBEntryGalaxyDebris($params) {
+    $debris = $params['debris'];
+    $targetPlanet = $params['targetPlanet'];
+
+    $targetID = $targetPlanet['id'];
+    $galaxyEntryIndexName = (
+        $targetPlanet['planet_type'] == 1 ?
+        'id_planet' :
+        'id_moon'
+    );
+
+    $query_UpdateGalaxyResources = [];
+
+    foreach (Resources\getKnownDebrisRecoverableResourceKeys() as $resourceKey) {
+        if (
+            !isset($debris[$resourceKey]) ||
+            !($debris[$resourceKey] > 0)
+        ) {
+            continue;
+        }
+
+        $query_UpdateGalaxyResources[] = "`{$resourceKey}` = `{$resourceKey}` + {$debris[$resourceKey]}";
+    }
+
+    if (empty($query_UpdateGalaxyResources)) {
+        return [
+            'isSuccess' => false,
+            'isUpdateUnnecessary' => true,
+        ];
+    }
+
+    $query_UpdateGalaxy = '';
+    $query_UpdateGalaxy .= "UPDATE {{table}} SET ";
+    $query_UpdateGalaxy .= implode(', ', $query_UpdateGalaxyResources) . " ";
+    $query_UpdateGalaxy .= "WHERE `{$galaxyEntryIndexName}` = {$targetID} LIMIT 1; ";
+    $query_UpdateGalaxy .= "-- MISSION ATTACK / DESTROY / GROUP ATTACK [Q02][FID: {$targetID}]";
+    doquery($query_UpdateGalaxy, 'galaxy');
+
+    return [
+        'isSuccess' => true,
+    ];
+}
+
+?>


### PR DESCRIPTION
## Summary:

Currently there are three places with galaxy entry debris update code duplicated. All of them should use a shared function to update the entry.
## Changelog:

- [x] Extract galaxy debris update code into separate util functions
- [x] Use the new updating functions in attacks handling functions:
    - [x] Regular attack
    - [x] Group attack (ACS)
    - [x] Moon destruction

## Related issues or PRs:

- #91 
