### PR TITLE
Refactor fleet missions' code | Part 04 | Morale modifiers calculation

### DIFF
--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -361,29 +361,17 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                 if($FleetStorage > 0)
                 {
                     $ResourceSteal_Factor = (COMBAT_RESOURCESTEAL_PERCENT / 100);
-                    if(MORALE_ENABLED)
-                    {
-                        $ResourceSteal_NewFactor = [];
-                        if(!$IsAbandoned AND $TargetUser['morale_level'] <= MORALE_PENALTY_RESOURCELOSE)
-                        {
-                            $ResourceSteal_NewFactor[] = MORALE_PENALTY_RESOURCELOSE_STEALPERCENT;
-                        }
-                        if($FleetRow['morale_level'] >= MORALE_BONUS_SOLOIDLERSTEAL AND $IdleHours >= (7 * 24))
-                        {
-                            $ResourceSteal_NewFactor[] = MORALE_BONUS_SOLOIDLERSTEAL_STEALPERCENT;
-                        }
-                        if($FleetRow['morale_level'] <= MORALE_PENALTY_STEAL)
-                        {
-                            $ResourceSteal_NewFactor[] = MORALE_PENALTY_STEAL_STEALPERCENT;
-                        }
-                        else if($FleetRow['morale_level'] <= MORALE_PENALTY_IDLERSTEAL AND $IdleHours >= (7 * 24))
-                        {
-                            $ResourceSteal_NewFactor[] = MORALE_PENALTY_IDLERSTEAL_STEALPERCENT;
-                        }
 
-                        if(!empty($ResourceSteal_NewFactor))
-                        {
-                            $ResourceSteal_Factor = (array_sum($ResourceSteal_NewFactor) / count($ResourceSteal_NewFactor)) / 100;
+                    if (MORALE_ENABLED) {
+                        $moralePillageModifiers = Flights\Utils\Modifiers\calculateMoralePillageModifiers([
+                            'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
+                            'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
+                            'isMainDefenderIdle' => ($IdleHours >= (7 * 24)),
+                            'isTargetAbandoned' => $IsAbandoned,
+                        ]);
+
+                        if (isset($moralePillageModifiers['pillageFactor'])) {
+                            $ResourceSteal_Factor = $moralePillageModifiers['pillageFactor'];
                         }
                     }
 

--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -125,40 +125,14 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
             $AttackersData[0]['morale'] = $FleetRow['morale_level'];
             $AttackersData[0]['moralePoints'] = $FleetRow['morale_points'];
 
-            // Bonuses
-            if($FleetRow['morale_level'] >= MORALE_BONUS_FLEETPOWERUP1)
-            {
-                $AttackingTechs[0]['TotalForceFactor'] = MORALE_BONUS_FLEETPOWERUP1_FACTOR;
-            }
-            if($FleetRow['morale_level'] >= MORALE_BONUS_FLEETSHIELDUP1)
-            {
-                $AttackingTechs[0]['TotalShieldFactor'] = MORALE_BONUS_FLEETSHIELDUP1_FACTOR;
-            }
-            if($FleetRow['morale_level'] >= MORALE_BONUS_FLEETSDADDITION)
-            {
-                $AttackingTechs[0]['SDAdd'] = MORALE_BONUS_FLEETSDADDITION_VALUE;
-            }
-            // Penalties
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN1)
-            {
-                $AttackingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN1_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN2)
-            {
-                $AttackingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN2_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN1)
-            {
-                $AttackingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN1_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN2)
-            {
-                $AttackingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN2_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETSDDOWN)
-            {
-                $AttackingTechs[0]['SDFactor'] = MORALE_PENALTY_FLEETSDDOWN_FACTOR;
-            }
+            $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
+                'moraleLevel' => $FleetRow['morale_level'],
+            ]);
+
+            $AttackingTechs[0] = array_merge(
+                $AttackingTechs[0],
+                $moraleCombatModifiers
+            );
 
             if(!$IsAbandoned)
             {
@@ -172,40 +146,14 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                 $DefendersData[0]['morale'] = $TargetUser['morale_level'];
                 $DefendersData[0]['moralePoints'] = $TargetUser['morale_points'];
 
-                // Bonuses
-                if($TargetUser['morale_level'] >= MORALE_BONUS_FLEETPOWERUP1)
-                {
-                    $DefendingTechs[0]['TotalForceFactor'] = MORALE_BONUS_FLEETPOWERUP1_FACTOR;
-                }
-                if($TargetUser['morale_level'] >= MORALE_BONUS_FLEETSHIELDUP1)
-                {
-                    $DefendingTechs[0]['TotalShieldFactor'] = MORALE_BONUS_FLEETSHIELDUP1_FACTOR;
-                }
-                if($TargetUser['morale_level'] >= MORALE_BONUS_FLEETSDADDITION)
-                {
-                    $DefendingTechs[0]['SDAdd'] = MORALE_BONUS_FLEETSDADDITION_VALUE;
-                }
-                // Penalties
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN1)
-                {
-                    $DefendingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN1_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN2)
-                {
-                    $DefendingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN2_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN1)
-                {
-                    $DefendingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN1_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN2)
-                {
-                    $DefendingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN2_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETSDDOWN)
-                {
-                    $DefendingTechs[0]['SDFactor'] = MORALE_PENALTY_FLEETSDDOWN_FACTOR;
-                }
+                $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
+                    'moraleLevel' => $TargetUser['morale_level'],
+                ]);
+
+                $DefendingTechs[0] = array_merge(
+                    $DefendingTechs[0],
+                    $moraleCombatModifiers
+                );
             }
         }
 
@@ -274,40 +222,14 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                             $DefendersData[$i]['moralePoints'] = $_TempCache['MoraleCache'][$FleetData['fleet_owner']]['points'];
                         }
 
-                        // Bonuses
-                        if($DefendersData[$i]['morale'] >= MORALE_BONUS_FLEETPOWERUP1)
-                        {
-                            $DefendingTechs[$i]['TotalForceFactor'] = MORALE_BONUS_FLEETPOWERUP1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] >= MORALE_BONUS_FLEETSHIELDUP1)
-                        {
-                            $DefendingTechs[$i]['TotalShieldFactor'] = MORALE_BONUS_FLEETSHIELDUP1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] >= MORALE_BONUS_FLEETSDADDITION)
-                        {
-                            $DefendingTechs[$i]['SDAdd'] = MORALE_BONUS_FLEETSDADDITION_VALUE;
-                        }
-                        // Penalties
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETPOWERDOWN1)
-                        {
-                            $DefendingTechs[$i]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETPOWERDOWN2)
-                        {
-                            $DefendingTechs[$i]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN2_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETSHIELDDOWN1)
-                        {
-                            $DefendingTechs[$i]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETSHIELDDOWN2)
-                        {
-                            $DefendingTechs[$i]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN2_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETSDDOWN)
-                        {
-                            $DefendingTechs[$i]['SDFactor'] = MORALE_PENALTY_FLEETSDDOWN_FACTOR;
-                        }
+                        $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
+                            'moraleLevel' => $DefendersData[$i]['morale'],
+                        ]);
+
+                        $DefendingTechs[$i] = array_merge(
+                            $DefendingTechs[$i],
+                            $moraleCombatModifiers
+                        );
                     }
 
                     $i += 1;

--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -360,25 +360,18 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
 
                 if($FleetStorage > 0)
                 {
-                    $ResourceSteal_Factor = (COMBAT_RESOURCESTEAL_PERCENT / 100);
-
-                    if (MORALE_ENABLED) {
-                        $moralePillageModifiers = Flights\Utils\Modifiers\calculateMoralePillageModifiers([
-                            'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
-                            'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
-                            'isMainDefenderIdle' => ($IdleHours >= (7 * 24)),
-                            'isTargetAbandoned' => $IsAbandoned,
-                        ]);
-
-                        if (isset($moralePillageModifiers['pillageFactor'])) {
-                            $ResourceSteal_Factor = $moralePillageModifiers['pillageFactor'];
-                        }
-                    }
+                    $pillageFactor = Flights\Utils\Calculations\calculatePillageFactor([
+                        'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
+                        'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
+                        'isMainDefenderIdle' => ($IdleHours >= (7 * 24)),
+                        'isTargetAbandoned' => $IsAbandoned,
+                        'attackerIDs' => $AttackersIDs,
+                    ]);
 
                     $resourcesPillage = Flights\Utils\Missions\calculateEvenResourcesPillage([
                         'maxPillagePerResource' => Flights\Utils\Missions\calculateMaxPlanetPillage([
                             'planet' => $TargetPlanet,
-                            'maxPillagePercentage' => $ResourceSteal_Factor,
+                            'maxPillagePercentage' => $pillageFactor,
                         ]),
                         'fleetTotalStorage' => $FleetStorage,
                     ]);

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -374,29 +374,17 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                 if($FleetStorage > 0)
                 {
                     $ResourceSteal_Factor = (COMBAT_RESOURCESTEAL_PERCENT / 100);
-                    if(MORALE_ENABLED)
-                    {
-                        $ResourceSteal_NewFactor = [];
-                        if(!$IsAbandoned AND $TargetUser['morale_level'] <= MORALE_PENALTY_RESOURCELOSE)
-                        {
-                            $ResourceSteal_NewFactor[] = MORALE_PENALTY_RESOURCELOSE_STEALPERCENT;
-                        }
-                        if($FleetRow['morale_level'] >= MORALE_BONUS_SOLOIDLERSTEAL AND $IdleHours >= (7 * 24))
-                        {
-                            $ResourceSteal_NewFactor[] = MORALE_BONUS_SOLOIDLERSTEAL_STEALPERCENT;
-                        }
-                        if($FleetRow['morale_level'] <= MORALE_PENALTY_STEAL)
-                        {
-                            $ResourceSteal_NewFactor[] = MORALE_PENALTY_STEAL_STEALPERCENT;
-                        }
-                        else if($FleetRow['morale_level'] <= MORALE_PENALTY_IDLERSTEAL AND $IdleHours >= (7 * 24))
-                        {
-                            $ResourceSteal_NewFactor[] = MORALE_PENALTY_IDLERSTEAL_STEALPERCENT;
-                        }
 
-                        if(!empty($ResourceSteal_NewFactor))
-                        {
-                            $ResourceSteal_Factor = (array_sum($ResourceSteal_NewFactor) / count($ResourceSteal_NewFactor)) / 100;
+                    if (MORALE_ENABLED) {
+                        $moralePillageModifiers = Flights\Utils\Modifiers\calculateMoralePillageModifiers([
+                            'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
+                            'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
+                            'isMainDefenderIdle' => ($IdleHours >= (7 * 24)),
+                            'isTargetAbandoned' => $IsAbandoned,
+                        ]);
+
+                        if (isset($moralePillageModifiers['pillageFactor'])) {
+                            $ResourceSteal_Factor = $moralePillageModifiers['pillageFactor'];
                         }
                     }
 

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -373,25 +373,18 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
 
                 if($FleetStorage > 0)
                 {
-                    $ResourceSteal_Factor = (COMBAT_RESOURCESTEAL_PERCENT / 100);
-
-                    if (MORALE_ENABLED) {
-                        $moralePillageModifiers = Flights\Utils\Modifiers\calculateMoralePillageModifiers([
-                            'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
-                            'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
-                            'isMainDefenderIdle' => ($IdleHours >= (7 * 24)),
-                            'isTargetAbandoned' => $IsAbandoned,
-                        ]);
-
-                        if (isset($moralePillageModifiers['pillageFactor'])) {
-                            $ResourceSteal_Factor = $moralePillageModifiers['pillageFactor'];
-                        }
-                    }
+                    $pillageFactor = Flights\Utils\Calculations\calculatePillageFactor([
+                        'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
+                        'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
+                        'isMainDefenderIdle' => ($IdleHours >= (7 * 24)),
+                        'isTargetAbandoned' => $IsAbandoned,
+                        'attackerIDs' => $AttackersIDs,
+                    ]);
 
                     $resourcesPillage = Flights\Utils\Missions\calculateEvenResourcesPillage([
                         'maxPillagePerResource' => Flights\Utils\Missions\calculateMaxPlanetPillage([
                             'planet' => $TargetPlanet,
-                            'maxPillagePercentage' => $ResourceSteal_Factor,
+                            'maxPillagePercentage' => $pillageFactor,
                         ]),
                         'fleetTotalStorage' => $FleetStorage,
                     ]);

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -132,40 +132,14 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
             $AttackersData[0]['morale'] = $FleetRow['morale_level'];
             $AttackersData[0]['moralePoints'] = $FleetRow['morale_points'];
 
-            // Bonuses
-            if($FleetRow['morale_level'] >= MORALE_BONUS_FLEETPOWERUP1)
-            {
-                $AttackingTechs[0]['TotalForceFactor'] = MORALE_BONUS_FLEETPOWERUP1_FACTOR;
-            }
-            if($FleetRow['morale_level'] >= MORALE_BONUS_FLEETSHIELDUP1)
-            {
-                $AttackingTechs[0]['TotalShieldFactor'] = MORALE_BONUS_FLEETSHIELDUP1_FACTOR;
-            }
-            if($FleetRow['morale_level'] >= MORALE_BONUS_FLEETSDADDITION)
-            {
-                $AttackingTechs[0]['SDAdd'] = MORALE_BONUS_FLEETSDADDITION_VALUE;
-            }
-            // Penalties
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN1)
-            {
-                $AttackingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN1_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN2)
-            {
-                $AttackingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN2_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN1)
-            {
-                $AttackingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN1_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN2)
-            {
-                $AttackingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN2_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETSDDOWN)
-            {
-                $AttackingTechs[0]['SDFactor'] = MORALE_PENALTY_FLEETSDDOWN_FACTOR;
-            }
+            $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
+                'moraleLevel' => $FleetRow['morale_level'],
+            ]);
+
+            $AttackingTechs[0] = array_merge(
+                $AttackingTechs[0],
+                $moraleCombatModifiers
+            );
 
             if(!$IsAbandoned)
             {
@@ -179,40 +153,14 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                 $DefendersData[0]['morale'] = $TargetUser['morale_level'];
                 $DefendersData[0]['moralePoints'] = $TargetUser['morale_points'];
 
-                // Bonuses
-                if($TargetUser['morale_level'] >= MORALE_BONUS_FLEETPOWERUP1)
-                {
-                    $DefendingTechs[0]['TotalForceFactor'] = MORALE_BONUS_FLEETPOWERUP1_FACTOR;
-                }
-                if($TargetUser['morale_level'] >= MORALE_BONUS_FLEETSHIELDUP1)
-                {
-                    $DefendingTechs[0]['TotalShieldFactor'] = MORALE_BONUS_FLEETSHIELDUP1_FACTOR;
-                }
-                if($TargetUser['morale_level'] >= MORALE_BONUS_FLEETSDADDITION)
-                {
-                    $DefendingTechs[0]['SDAdd'] = MORALE_BONUS_FLEETSDADDITION_VALUE;
-                }
-                // Penalties
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN1)
-                {
-                    $DefendingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN1_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN2)
-                {
-                    $DefendingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN2_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN1)
-                {
-                    $DefendingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN1_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN2)
-                {
-                    $DefendingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN2_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETSDDOWN)
-                {
-                    $DefendingTechs[0]['SDFactor'] = MORALE_PENALTY_FLEETSDDOWN_FACTOR;
-                }
+                $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
+                    'moraleLevel' => $TargetUser['morale_level'],
+                ]);
+
+                $DefendingTechs[0] = array_merge(
+                    $DefendingTechs[0],
+                    $moraleCombatModifiers
+                );
             }
         }
 
@@ -281,40 +229,14 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                             $DefendersData[$i]['moralePoints'] = $_TempCache['MoraleCache'][$FleetData['fleet_owner']]['points'];
                         }
 
-                        // Bonuses
-                        if($DefendersData[$i]['morale'] >= MORALE_BONUS_FLEETPOWERUP1)
-                        {
-                            $DefendingTechs[$i]['TotalForceFactor'] = MORALE_BONUS_FLEETPOWERUP1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] >= MORALE_BONUS_FLEETSHIELDUP1)
-                        {
-                            $DefendingTechs[$i]['TotalShieldFactor'] = MORALE_BONUS_FLEETSHIELDUP1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] >= MORALE_BONUS_FLEETSDADDITION)
-                        {
-                            $DefendingTechs[$i]['SDAdd'] = MORALE_BONUS_FLEETSDADDITION_VALUE;
-                        }
-                        // Penalties
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETPOWERDOWN1)
-                        {
-                            $DefendingTechs[$i]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETPOWERDOWN2)
-                        {
-                            $DefendingTechs[$i]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN2_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETSHIELDDOWN1)
-                        {
-                            $DefendingTechs[$i]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETSHIELDDOWN2)
-                        {
-                            $DefendingTechs[$i]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN2_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETSDDOWN)
-                        {
-                            $DefendingTechs[$i]['SDFactor'] = MORALE_PENALTY_FLEETSDDOWN_FACTOR;
-                        }
+                        $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
+                            'moraleLevel' => $DefendersData[$i]['morale'],
+                        ]);
+
+                        $DefendingTechs[$i] = array_merge(
+                            $DefendingTechs[$i],
+                            $moraleCombatModifiers
+                        );
                     }
 
                     $i += 1;

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -441,12 +441,14 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 $ResourceSteal_Factor = (COMBAT_RESOURCESTEAL_PERCENT / 100);
 
                 if (MORALE_ENABLED) {
+                    $hasOnlyOneAttacker = (count($AttackersIDs) === 1);
+
                     $moralePillageModifiers = Flights\Utils\Modifiers\calculateMoralePillageModifiers([
                         'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
                         'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
                         'isMainDefenderIdle' => ($IdleHours >= (7 * 24)),
                         'isTargetAbandoned' => $IsAbandoned,
-                        'areBonusModifiersDisabled' => true,
+                        'areBonusModifiersDisabled' => !$hasOnlyOneAttacker,
                     ]);
 
                     if (isset($moralePillageModifiers['pillageFactor'])) {

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -438,27 +438,17 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
         {
             if($Result === COMBAT_ATK)
             {
-                $ResourceSteal_Factor = (COMBAT_RESOURCESTEAL_PERCENT / 100);
-
-                if (MORALE_ENABLED) {
-                    $hasOnlyOneAttacker = (count($AttackersIDs) === 1);
-
-                    $moralePillageModifiers = Flights\Utils\Modifiers\calculateMoralePillageModifiers([
-                        'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
-                        'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
-                        'isMainDefenderIdle' => ($IdleHours >= (7 * 24)),
-                        'isTargetAbandoned' => $IsAbandoned,
-                        'areBonusModifiersDisabled' => !$hasOnlyOneAttacker,
-                    ]);
-
-                    if (isset($moralePillageModifiers['pillageFactor'])) {
-                        $ResourceSteal_Factor = $moralePillageModifiers['pillageFactor'];
-                    }
-                }
+                $pillageFactor = Flights\Utils\Calculations\calculatePillageFactor([
+                    'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
+                    'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
+                    'isMainDefenderIdle' => ($IdleHours >= (7 * 24)),
+                    'isTargetAbandoned' => $IsAbandoned,
+                    'attackerIDs' => $AttackersIDs,
+                ]);
 
                 $maxResourcesPillage = Flights\Utils\Missions\calculateMaxPlanetPillage([
                     'planet' => $TargetPlanet,
-                    'maxPillagePercentage' => $ResourceSteal_Factor,
+                    'maxPillagePercentage' => $pillageFactor,
                 ]);
             }
 

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -148,40 +148,14 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                             $DefendersData[$i]['moralePoints'] = $_TempCache['MoraleCache'][$FleetData['fleet_owner']]['points'];
                         }
 
-                        // Bonuses
-                        if($DefendersData[$i]['morale'] >= MORALE_BONUS_FLEETPOWERUP1)
-                        {
-                            $DefendingTechs[$i]['TotalForceFactor'] = MORALE_BONUS_FLEETPOWERUP1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] >= MORALE_BONUS_FLEETSHIELDUP1)
-                        {
-                            $DefendingTechs[$i]['TotalShieldFactor'] = MORALE_BONUS_FLEETSHIELDUP1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] >= MORALE_BONUS_FLEETSDADDITION)
-                        {
-                            $DefendingTechs[$i]['SDAdd'] = MORALE_BONUS_FLEETSDADDITION_VALUE;
-                        }
-                        // Penalties
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETPOWERDOWN1)
-                        {
-                            $DefendingTechs[$i]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETPOWERDOWN2)
-                        {
-                            $DefendingTechs[$i]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN2_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETSHIELDDOWN1)
-                        {
-                            $DefendingTechs[$i]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN1_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETSHIELDDOWN2)
-                        {
-                            $DefendingTechs[$i]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN2_FACTOR;
-                        }
-                        if($DefendersData[$i]['morale'] <= MORALE_PENALTY_FLEETSDDOWN)
-                        {
-                            $DefendingTechs[$i]['SDFactor'] = MORALE_PENALTY_FLEETSDDOWN_FACTOR;
-                        }
+                        $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
+                            'moraleLevel' => $DefendersData[$i]['morale'],
+                        ]);
+
+                        $DefendingTechs[$i] = array_merge(
+                            $DefendingTechs[$i],
+                            $moraleCombatModifiers
+                        );
                     }
 
                     $i += 1;
@@ -296,40 +270,14 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                         $AttackersData[$i]['moralePoints'] = $_TempCache['MoraleCache'][$FleetData['fleet_owner']]['points'];
                     }
 
-                    // Bonuses
-                    if($AttackersData[$i]['morale'] >= MORALE_BONUS_FLEETPOWERUP1)
-                    {
-                        $AttackingTechs[$i]['TotalForceFactor'] = MORALE_BONUS_FLEETPOWERUP1_FACTOR;
-                    }
-                    if($AttackersData[$i]['morale'] >= MORALE_BONUS_FLEETSHIELDUP1)
-                    {
-                        $AttackingTechs[$i]['TotalShieldFactor'] = MORALE_BONUS_FLEETSHIELDUP1_FACTOR;
-                    }
-                    if($AttackersData[$i]['morale'] >= MORALE_BONUS_FLEETSDADDITION)
-                    {
-                        $AttackingTechs[$i]['SDAdd'] = MORALE_BONUS_FLEETSDADDITION_VALUE;
-                    }
-                    // Penalties
-                    if($AttackersData[$i]['morale'] <= MORALE_PENALTY_FLEETPOWERDOWN1)
-                    {
-                        $AttackingTechs[$i]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN1_FACTOR;
-                    }
-                    if($AttackersData[$i]['morale'] <= MORALE_PENALTY_FLEETPOWERDOWN2)
-                    {
-                        $AttackingTechs[$i]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN2_FACTOR;
-                    }
-                    if($AttackersData[$i]['morale'] <= MORALE_PENALTY_FLEETSHIELDDOWN1)
-                    {
-                        $AttackingTechs[$i]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN1_FACTOR;
-                    }
-                    if($AttackersData[$i]['morale'] <= MORALE_PENALTY_FLEETSHIELDDOWN2)
-                    {
-                        $AttackingTechs[$i]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN2_FACTOR;
-                    }
-                    if($AttackersData[$i]['morale'] <= MORALE_PENALTY_FLEETSDDOWN)
-                    {
-                        $AttackingTechs[$i]['SDFactor'] = MORALE_PENALTY_FLEETSDDOWN_FACTOR;
-                    }
+                    $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
+                        'moraleLevel' => $AttackersData[$i]['morale'],
+                    ]);
+
+                    $AttackingTechs[$i] = array_merge(
+                        $AttackingTechs[$i],
+                        $moraleCombatModifiers
+                    );
                 }
 
                 $i += 1;
@@ -360,40 +308,14 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 );
             }
 
-            // Bonuses
-            if($FleetRow['morale_level'] >= MORALE_BONUS_FLEETPOWERUP1)
-            {
-                $AttackingTechs[0]['TotalForceFactor'] = MORALE_BONUS_FLEETPOWERUP1_FACTOR;
-            }
-            if($FleetRow['morale_level'] >= MORALE_BONUS_FLEETSHIELDUP1)
-            {
-                $AttackingTechs[0]['TotalShieldFactor'] = MORALE_BONUS_FLEETSHIELDUP1_FACTOR;
-            }
-            if($FleetRow['morale_level'] >= MORALE_BONUS_FLEETSDADDITION)
-            {
-                $AttackingTechs[0]['SDAdd'] = MORALE_BONUS_FLEETSDADDITION_VALUE;
-            }
-            // Penalties
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN1)
-            {
-                $AttackingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN1_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN2)
-            {
-                $AttackingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN2_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN1)
-            {
-                $AttackingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN1_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN2)
-            {
-                $AttackingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN2_FACTOR;
-            }
-            if($FleetRow['morale_level'] <= MORALE_PENALTY_FLEETSDDOWN)
-            {
-                $AttackingTechs[0]['SDFactor'] = MORALE_PENALTY_FLEETSDDOWN_FACTOR;
-            }
+            $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
+                'moraleLevel' => $FleetRow['morale_level'],
+            ]);
+
+            $AttackingTechs[0] = array_merge(
+                $AttackingTechs[0],
+                $moraleCombatModifiers
+            );
 
             if(!$IsAbandoned)
             {
@@ -407,40 +329,14 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 $DefendersData[0]['morale'] = $TargetUser['morale_level'];
                 $DefendersData[0]['moralePoints'] = $TargetUser['morale_points'];
 
-                // Bonuses
-                if($TargetUser['morale_level'] >= MORALE_BONUS_FLEETPOWERUP1)
-                {
-                    $DefendingTechs[0]['TotalForceFactor'] = MORALE_BONUS_FLEETPOWERUP1_FACTOR;
-                }
-                if($TargetUser['morale_level'] >= MORALE_BONUS_FLEETSHIELDUP1)
-                {
-                    $DefendingTechs[0]['TotalShieldFactor'] = MORALE_BONUS_FLEETSHIELDUP1_FACTOR;
-                }
-                if($TargetUser['morale_level'] >= MORALE_BONUS_FLEETSDADDITION)
-                {
-                    $DefendingTechs[0]['SDAdd'] = MORALE_BONUS_FLEETSDADDITION_VALUE;
-                }
-                // Penalties
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN1)
-                {
-                    $DefendingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN1_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETPOWERDOWN2)
-                {
-                    $DefendingTechs[0]['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN2_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN1)
-                {
-                    $DefendingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN1_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETSHIELDDOWN2)
-                {
-                    $DefendingTechs[0]['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN2_FACTOR;
-                }
-                if($TargetUser['morale_level'] <= MORALE_PENALTY_FLEETSDDOWN)
-                {
-                    $DefendingTechs[0]['SDFactor'] = MORALE_PENALTY_FLEETSDDOWN_FACTOR;
-                }
+                $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
+                    'moraleLevel' => $TargetUser['morale_level'],
+                ]);
+
+                $DefendingTechs[0] = array_merge(
+                    $DefendingTechs[0],
+                    $moraleCombatModifiers
+                );
             }
         }
 

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -439,25 +439,18 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
             if($Result === COMBAT_ATK)
             {
                 $ResourceSteal_Factor = (COMBAT_RESOURCESTEAL_PERCENT / 100);
-                if(MORALE_ENABLED)
-                {
-                    $ResourceSteal_NewFactor = [];
-                    if(!$IsAbandoned AND $TargetUser['morale_level'] <= MORALE_PENALTY_RESOURCELOSE)
-                    {
-                        $ResourceSteal_NewFactor[] = MORALE_PENALTY_RESOURCELOSE_STEALPERCENT;
-                    }
-                    if($FleetRow['morale_level'] <= MORALE_PENALTY_STEAL)
-                    {
-                        $ResourceSteal_NewFactor[] = MORALE_PENALTY_STEAL_STEALPERCENT;
-                    }
-                    else if($FleetRow['morale_level'] <= MORALE_PENALTY_IDLERSTEAL AND $IdleHours >= (7 * 24))
-                    {
-                        $ResourceSteal_NewFactor[] = MORALE_PENALTY_IDLERSTEAL_STEALPERCENT;
-                    }
 
-                    if(!empty($ResourceSteal_NewFactor))
-                    {
-                        $ResourceSteal_Factor = (array_sum($ResourceSteal_NewFactor) / count($ResourceSteal_NewFactor)) / 100;
+                if (MORALE_ENABLED) {
+                    $moralePillageModifiers = Flights\Utils\Modifiers\calculateMoralePillageModifiers([
+                        'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
+                        'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
+                        'isMainDefenderIdle' => ($IdleHours >= (7 * 24)),
+                        'isTargetAbandoned' => $IsAbandoned,
+                        'areBonusModifiersDisabled' => true,
+                    ]);
+
+                    if (isset($moralePillageModifiers['pillageFactor'])) {
+                        $ResourceSteal_Factor = $moralePillageModifiers['pillageFactor'];
                     }
                 }
 

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -8,6 +8,7 @@ call_user_func(function () {
 
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');
+    include($includePath . './utils/modifiers/calculateMoraleModifiers.utils.php');
     include($includePath . './utils/missions.utils.php');
 
 });

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -6,6 +6,7 @@ call_user_func(function () {
 
     $includePath = $_EnginePath . 'modules/flights/';
 
+    include($includePath . './utils/calculations/calculatePillageFactor.utils.php');
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');
     include($includePath . './utils/modifiers/calculateMoraleModifiers.utils.php');

--- a/modules/flights/utils/calculations/calculatePillageFactor.utils.php
+++ b/modules/flights/utils/calculations/calculatePillageFactor.utils.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Calculations;
+
+use UniEngine\Engine\Modules\Flights;
+
+/**
+ * @param array $params
+ * @param number $params['mainAttackerMoraleLevel']
+ * @param number $params['mainDefenderMoraleLevel']
+ * @param boolean $params['isMainDefenderIdle']
+ * @param boolean $params['isTargetAbandoned']
+ * @param array $params['attackerIDs']
+ */
+function calculatePillageFactor($params) {
+    $basePillageFactor = _getBasePillageFactor();
+
+    if (!MORALE_ENABLED) {
+        return $basePillageFactor;
+    }
+
+    $moraleModifiedPillageFactor = _getMoraleModifiedPillageFactor($params);
+
+    if ($moraleModifiedPillageFactor === null) {
+        return $basePillageFactor;
+    }
+
+    return $moraleModifiedPillageFactor;
+}
+
+function _getBasePillageFactor() {
+    return (COMBAT_RESOURCESTEAL_PERCENT / 100);
+}
+
+/**
+ * @see calculatePillageFactor()
+ */
+function _getMoraleModifiedPillageFactor($params) {
+    $hasOnlyOneAttacker = (count($params['attackerIDs']) === 1);
+
+    $moralePillageModifiers = Flights\Utils\Modifiers\calculateMoralePillageModifiers([
+        'mainAttackerMoraleLevel' => $params['mainAttackerMoraleLevel'],
+        'mainDefenderMoraleLevel' => $params['mainDefenderMoraleLevel'],
+        'isMainDefenderIdle' => $params['isMainDefenderIdle'],
+        'isTargetAbandoned' => $params['isTargetAbandoned'],
+        'areBonusModifiersDisabled' => !$hasOnlyOneAttacker,
+    ]);
+
+    if (!isset($moralePillageModifiers['pillageFactor'])) {
+        return null;
+    }
+
+    return $moralePillageModifiers['pillageFactor'];
+}
+
+?>

--- a/modules/flights/utils/modifiers/calculateMoraleModifiers.utils.php
+++ b/modules/flights/utils/modifiers/calculateMoraleModifiers.utils.php
@@ -40,4 +40,55 @@ function calculateMoraleCombatModifiers ($props) {
     return $moraleCombatModifiers;
 }
 
+/**
+ * @param array $props
+ * @param number $props['mainAttackerMoraleLevel']
+ * @param number $props['mainDefenderMoraleLevel']
+ * @param boolean $props['isMainDefenderIdle']
+ * @param boolean $props['isTargetAbandoned']
+ */
+function calculateMoralePillageModifiers ($props) {
+    $mainAttackerMoraleLevel = $props['mainAttackerMoraleLevel'];
+    $mainDefenderMoraleLevel = $props['mainDefenderMoraleLevel'];
+    $isMainDefenderIdle = $props['isMainDefenderIdle'];
+    $isTargetAbandoned = $props['isTargetAbandoned'];
+
+    $modifiers = [];
+    $pillageModifiers = [];
+
+    if (
+        !$isTargetAbandoned &&
+        $mainDefenderMoraleLevel <= MORALE_PENALTY_RESOURCELOSE
+    ) {
+        $pillageModifiers[] = MORALE_PENALTY_RESOURCELOSE_STEALPERCENT;
+    }
+    if (
+        $mainAttackerMoraleLevel >= MORALE_BONUS_SOLOIDLERSTEAL &&
+        $isMainDefenderIdle
+    ) {
+        $pillageModifiers[] = MORALE_BONUS_SOLOIDLERSTEAL_STEALPERCENT;
+    }
+    if ($mainAttackerMoraleLevel <= MORALE_PENALTY_STEAL) {
+        $pillageModifiers[] = MORALE_PENALTY_STEAL_STEALPERCENT;
+    }
+    else if (
+        $mainAttackerMoraleLevel <= MORALE_PENALTY_IDLERSTEAL &&
+        $isMainDefenderIdle
+    ) {
+        $pillageModifiers[] = MORALE_PENALTY_IDLERSTEAL_STEALPERCENT;
+    }
+
+    if (!empty($pillageModifiers)) {
+        $modifiers['pillageFactor'] = (
+            (
+                array_sum($pillageModifiers) /
+                count($pillageModifiers)
+            ) /
+            100
+        );
+    }
+
+    return $modifiers;
+}
+
 ?>

--- a/modules/flights/utils/modifiers/calculateMoraleModifiers.utils.php
+++ b/modules/flights/utils/modifiers/calculateMoraleModifiers.utils.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Modifiers;
+
+/**
+ * @param array $props
+ * @param number $props['moraleLevel']
+ */
+function calculateMoraleModifiers ($props) {
+    $moraleLevel = $props['moraleLevel'];
+
+    $moraleCombatModifiers = [];
+
+    if ($moraleLevel >= MORALE_BONUS_FLEETPOWERUP1) {
+        $moraleCombatModifiers['TotalForceFactor'] = MORALE_BONUS_FLEETPOWERUP1_FACTOR;
+    }
+    if ($moraleLevel >= MORALE_BONUS_FLEETSHIELDUP1) {
+        $moraleCombatModifiers['TotalShieldFactor'] = MORALE_BONUS_FLEETSHIELDUP1_FACTOR;
+    }
+    if ($moraleLevel >= MORALE_BONUS_FLEETSDADDITION) {
+        $moraleCombatModifiers['SDAdd'] = MORALE_BONUS_FLEETSDADDITION_VALUE;
+    }
+    // Penalties
+    if ($moraleLevel <= MORALE_PENALTY_FLEETPOWERDOWN1) {
+        $moraleCombatModifiers['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN1_FACTOR;
+    }
+    if ($moraleLevel <= MORALE_PENALTY_FLEETPOWERDOWN2) {
+        $moraleCombatModifiers['TotalForceFactor'] = MORALE_PENALTY_FLEETPOWERDOWN2_FACTOR;
+    }
+    if ($moraleLevel <= MORALE_PENALTY_FLEETSHIELDDOWN1) {
+        $moraleCombatModifiers['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN1_FACTOR;
+    }
+    if ($moraleLevel <= MORALE_PENALTY_FLEETSHIELDDOWN2) {
+        $moraleCombatModifiers['TotalShieldFactor'] = MORALE_PENALTY_FLEETSHIELDDOWN2_FACTOR;
+    }
+    if ($moraleLevel <= MORALE_PENALTY_FLEETSDDOWN) {
+        $moraleCombatModifiers['SDFactor'] = MORALE_PENALTY_FLEETSDDOWN_FACTOR;
+    }
+
+    return $moraleCombatModifiers;
+}
+
+?>

--- a/modules/flights/utils/modifiers/calculateMoraleModifiers.utils.php
+++ b/modules/flights/utils/modifiers/calculateMoraleModifiers.utils.php
@@ -46,15 +46,30 @@ function calculateMoraleCombatModifiers ($props) {
  * @param number $props['mainDefenderMoraleLevel']
  * @param boolean $props['isMainDefenderIdle']
  * @param boolean $props['isTargetAbandoned']
+ * @param boolean $props['areBonusModifiersDisabled'] Default: false
  */
 function calculateMoralePillageModifiers ($props) {
     $mainAttackerMoraleLevel = $props['mainAttackerMoraleLevel'];
     $mainDefenderMoraleLevel = $props['mainDefenderMoraleLevel'];
     $isMainDefenderIdle = $props['isMainDefenderIdle'];
     $isTargetAbandoned = $props['isTargetAbandoned'];
+    $areBonusModifiersDisabled = (
+        isset($props['areBonusModifiersDisabled']) ?
+            $props['areBonusModifiersDisabled'] :
+            false
+    );
 
     $modifiers = [];
     $pillageModifiers = [];
+
+    if (!$areBonusModifiersDisabled) {
+        if (
+            $mainAttackerMoraleLevel >= MORALE_BONUS_SOLOIDLERSTEAL &&
+            $isMainDefenderIdle
+        ) {
+            $pillageModifiers[] = MORALE_BONUS_SOLOIDLERSTEAL_STEALPERCENT;
+        }
+    }
 
     if (
         !$isTargetAbandoned &&
@@ -62,16 +77,9 @@ function calculateMoralePillageModifiers ($props) {
     ) {
         $pillageModifiers[] = MORALE_PENALTY_RESOURCELOSE_STEALPERCENT;
     }
-    if (
-        $mainAttackerMoraleLevel >= MORALE_BONUS_SOLOIDLERSTEAL &&
-        $isMainDefenderIdle
-    ) {
-        $pillageModifiers[] = MORALE_BONUS_SOLOIDLERSTEAL_STEALPERCENT;
-    }
     if ($mainAttackerMoraleLevel <= MORALE_PENALTY_STEAL) {
         $pillageModifiers[] = MORALE_PENALTY_STEAL_STEALPERCENT;
-    }
-    else if (
+    } else if (
         $mainAttackerMoraleLevel <= MORALE_PENALTY_IDLERSTEAL &&
         $isMainDefenderIdle
     ) {

--- a/modules/flights/utils/modifiers/calculateMoraleModifiers.utils.php
+++ b/modules/flights/utils/modifiers/calculateMoraleModifiers.utils.php
@@ -6,7 +6,7 @@ namespace UniEngine\Engine\Modules\Flights\Utils\Modifiers;
  * @param array $props
  * @param number $props['moraleLevel']
  */
-function calculateMoraleModifiers ($props) {
+function calculateMoraleCombatModifiers ($props) {
     $moraleLevel = $props['moraleLevel'];
 
     $moraleCombatModifiers = [];

--- a/modules/flights/utils/modifiers/index.php
+++ b/modules/flights/utils/modifiers/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>


### PR DESCRIPTION
## Summary:

Currently there are several places where morale-related modifiers are calculated manually for each attacker and defender, also duplicated in several files. All of these modifiers are applied identically, therefore they should be calculated using a shared utility function.

## Changelog:

- [x] Extract morale combat modifiers calculating function
- [x] Use the new combat updating functions in attacks handling functions:
    - [x] Regular attack
    - [x] Group attack (ACS)
    - [x] Moon destruction
- [x] Extract morale pillage modifiers calculating function
- [x] Use the new pillage updating functions in attacks handling functions:
    - [x] Regular attack
    - [x] Group attack (ACS)
    - [x] Moon destruction
- [x] Bugfix: when sending a united attack by yourself (only one attacker), apply morale BONUS when pillaging

## Related issues or PRs:

- #91 
