### PR TITLE
Refactor fleet missions' code | Part 05 | User technologies initialization

### DIFF
--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -64,18 +64,10 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
         $AttackingFleets = array();
         $DefendingFleets = array();
 
-        $DefendingTechs[0] = array
-        (
-            109 => $TargetUser['tech_weapons'],
-            110 => $TargetUser['tech_armour'],
-            111 => $TargetUser['tech_shielding'],
-            120 => $TargetUser['tech_laser'],
-            121 => $TargetUser['tech_ion'],
-            122 => $TargetUser['tech_plasma'],
-            125 => $TargetUser['tech_antimatter'],
-            126 => $TargetUser['tech_disintegration'],
-            199 => $TargetUser['tech_graviton']
-        );
+        $DefendingTechs[0] = Flights\Utils\Initializers\initCombatTechnologiesMap([
+            'user' => $TargetUser,
+        ]);
+
         $DefendersData[0] = array
         (
             'id' => $TargetUser['id'],
@@ -88,18 +80,10 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
             $DefendersData[0]['ally'] = $TargetUser['ally_tag'];
         }
 
-        $AttackingTechs[0] = array
-        (
-            109 => $FleetRow['tech_weapons'],
-            110 => $FleetRow['tech_armour'],
-            111 => $FleetRow['tech_shielding'],
-            120 => $FleetRow['tech_laser'],
-            121 => $FleetRow['tech_ion'],
-            122 => $FleetRow['tech_plasma'],
-            125 => $FleetRow['tech_antimatter'],
-            126 => $FleetRow['tech_disintegration'],
-            199 => $FleetRow['tech_graviton']
-        );
+        $AttackingTechs[0] = Flights\Utils\Initializers\initCombatTechnologiesMap([
+            'user' => $FleetRow,
+        ]);
+
         $AttackersData[0] = array
         (
             'id' => $FleetRow['fleet_owner'],
@@ -167,18 +151,9 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                 {
                     $DefendingFleets[$i] = String2Array($FleetData['fleet_array']);
                     $DefendingFleetID[$i] = $FleetData['fleet_id'];
-                    $DefendingTechs[$i] = array
-                    (
-                        109 => $FleetData['tech_weapons'],
-                        110 => $FleetData['tech_armour'],
-                        111 => $FleetData['tech_shielding'],
-                        120 => $FleetData['tech_laser'],
-                        121 => $FleetData['tech_ion'],
-                        122 => $FleetData['tech_plasma'],
-                        125 => $FleetData['tech_antimatter'],
-                        126 => $FleetData['tech_disintegration'],
-                        199 => $FleetData['tech_graviton']
-                    );
+                    $DefendingTechs[$i] = Flights\Utils\Initializers\initCombatTechnologiesMap([
+                        'user' => $FleetData,
+                    ]);
                     $DefendersData[$i] = array
                     (
                         'id' => $FleetData['fleet_owner'],

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -71,18 +71,10 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
         $AttackingFleets = array();
         $DefendingFleets = array();
 
-        $DefendingTechs[0] = array
-        (
-            109 => $TargetUser['tech_weapons'],
-            110 => $TargetUser['tech_armour'],
-            111 => $TargetUser['tech_shielding'],
-            120 => $TargetUser['tech_laser'],
-            121 => $TargetUser['tech_ion'],
-            122 => $TargetUser['tech_plasma'],
-            125 => $TargetUser['tech_antimatter'],
-            126 => $TargetUser['tech_disintegration'],
-            199 => $TargetUser['tech_graviton']
-        );
+        $DefendingTechs[0] = Flights\Utils\Initializers\initCombatTechnologiesMap([
+            'user' => $TargetUser,
+        ]);
+
         $DefendersData[0] = array
         (
             'id' => $TargetUser['id'],
@@ -95,18 +87,10 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
             $DefendersData[0]['ally'] = $TargetUser['ally_tag'];
         }
 
-        $AttackingTechs[0] = array
-        (
-            109 => $FleetRow['tech_weapons'],
-            110 => $FleetRow['tech_armour'],
-            111 => $FleetRow['tech_shielding'],
-            120 => $FleetRow['tech_laser'],
-            121 => $FleetRow['tech_ion'],
-            122 => $FleetRow['tech_plasma'],
-            125 => $FleetRow['tech_antimatter'],
-            126 => $FleetRow['tech_disintegration'],
-            199 => $FleetRow['tech_graviton']
-        );
+        $AttackingTechs[0] = Flights\Utils\Initializers\initCombatTechnologiesMap([
+            'user' => $FleetRow,
+        ]);
+
         $AttackersData[0] = array
         (
             'id' => $FleetRow['fleet_owner'],
@@ -174,18 +158,9 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                 {
                     $DefendingFleets[$i] = String2Array($FleetData['fleet_array']);
                     $DefendingFleetID[$i] = $FleetData['fleet_id'];
-                    $DefendingTechs[$i] = array
-                    (
-                        109 => $FleetData['tech_weapons'],
-                        110 => $FleetData['tech_armour'],
-                        111 => $FleetData['tech_shielding'],
-                        120 => $FleetData['tech_laser'],
-                        121 => $FleetData['tech_ion'],
-                        122 => $FleetData['tech_plasma'],
-                        125 => $FleetData['tech_antimatter'],
-                        126 => $FleetData['tech_disintegration'],
-                        199 => $FleetData['tech_graviton']
-                    );
+                    $DefendingTechs[$i] = Flights\Utils\Initializers\initCombatTechnologiesMap([
+                        'user' => $FleetData,
+                    ]);
                     $DefendersData[$i] = array
                     (
                         'id' => $FleetData['fleet_owner'],

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -59,18 +59,10 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
         // Create data arrays for attacker and main defender
         $DefendersIDs[] = $TargetUser['id'];
 
-        $DefendingTechs[0] = array
-        (
-            109 => $TargetUser['tech_weapons'],
-            110 => $TargetUser['tech_armour'],
-            111 => $TargetUser['tech_shielding'],
-            120 => $TargetUser['tech_laser'],
-            121 => $TargetUser['tech_ion'],
-            122 => $TargetUser['tech_plasma'],
-            125 => $TargetUser['tech_antimatter'],
-            126 => $TargetUser['tech_disintegration'],
-            199 => $TargetUser['tech_graviton']
-        );
+        $DefendingTechs[0] = Flights\Utils\Initializers\initCombatTechnologiesMap([
+            'user' => $TargetUser,
+        ]);
+
         $DefendersData[0] = array
         (
             'id' => $TargetUser['id'],
@@ -93,18 +85,9 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 {
                     $DefendingFleets[$i] = String2Array($FleetData['fleet_array']);
                     $DefendingFleetID[$i] = $FleetData['fleet_id'];
-                    $DefendingTechs[$i] = array
-                    (
-                        109 => $FleetData['tech_weapons'],
-                        110 => $FleetData['tech_armour'],
-                        111 => $FleetData['tech_shielding'],
-                        120 => $FleetData['tech_laser'],
-                        121 => $FleetData['tech_ion'],
-                        122 => $FleetData['tech_plasma'],
-                        125 => $FleetData['tech_antimatter'],
-                        126 => $FleetData['tech_disintegration'],
-                        199 => $FleetData['tech_graviton']
-                    );
+                    $DefendingTechs[$i] = Flights\Utils\Initializers\initCombatTechnologiesMap([
+                        'user' => $FleetData,
+                    ]);
                     $DefendersData[$i] = array
                     (
                         'id' => $FleetData['fleet_owner'],
@@ -170,18 +153,10 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
         $AttackingFleetRes[$FleetRow['fleet_id']]['crystal'] = (isset($FleetRow['fleet_resouce_crystal']) ? $FleetRow['fleet_resouce_crystal'] : 0);
         $AttackingFleetRes[$FleetRow['fleet_id']]['deuterium'] = (isset($FleetRow['fleet_resouce_deuterium']) ? $FleetRow['fleet_resouce_deuterium'] : 0);
 
-        $AttackingTechs[0] = array
-        (
-            109 => $FleetRow['tech_weapons'],
-            110 => $FleetRow['tech_armour'],
-            111 => $FleetRow['tech_shielding'],
-            120 => $FleetRow['tech_laser'],
-            121 => $FleetRow['tech_ion'],
-            122 => $FleetRow['tech_plasma'],
-            125 => $FleetRow['tech_antimatter'],
-            126 => $FleetRow['tech_disintegration'],
-            199 => $FleetRow['tech_graviton']
-        );
+        $AttackingTechs[0] = Flights\Utils\Initializers\initCombatTechnologiesMap([
+            'user' => $FleetRow,
+        ]);
+
         $AttackersData[0] = array
         (
             'id' => $FleetRow['fleet_owner'],
@@ -206,18 +181,9 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 $AttackingFleetRes[$FleetData['fleet_id']]['crystal'] = (isset($FleetData['fleet_resouce_crystal']) ? $FleetData['fleet_resouce_crystal'] : 0);
                 $AttackingFleetRes[$FleetData['fleet_id']]['deuterium'] = (isset($FleetData['fleet_resouce_deuterium']) ? $FleetData['fleet_resouce_deuterium'] : 0);
                 $AttackingFleetID[$i] = $FleetData['fleet_id'];
-                $AttackingTechs[$i] = array
-                (
-                    109 => $FleetData['tech_weapons'],
-                    110 => $FleetData['tech_armour'],
-                    111 => $FleetData['tech_shielding'],
-                    120 => $FleetData['tech_laser'],
-                    121 => $FleetData['tech_ion'],
-                    122 => $FleetData['tech_plasma'],
-                    125 => $FleetData['tech_antimatter'],
-                    126 => $FleetData['tech_disintegration'],
-                    199 => $FleetData['tech_graviton']
-                );
+                $AttackingTechs[$i] = Flights\Utils\Initializers\initCombatTechnologiesMap([
+                    'user' => $FleetData,
+                ]);
                 $AttackersData[$i] = array
                 (
                     'id' => $FleetData['fleet_owner'],

--- a/includes/vars_elementcategories.php
+++ b/includes/vars_elementcategories.php
@@ -14,6 +14,10 @@ if(defined('INSIDE'))
 
     $_Vars_ElementCategories['buildOn'][1]              = array(1, 2, 3, 4, 12, 14, 15, 21, 22, 23, 24, 31, 33, 34, 44, 50);
     $_Vars_ElementCategories['buildOn'][3]              = array(14, 21, 22, 23, 24, 34, 41, 42, 43);
+
+    $_Vars_ElementCategories['techPurpose'] = [
+        'combat' => [ 109, 110, 111, 120, 121, 122, 125, 126, 199, ],
+    ];
 }
 
 ?>

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -9,6 +9,7 @@ call_user_func(function () {
     include($includePath . './utils/calculations/calculatePillageFactor.utils.php');
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');
+    include($includePath . './utils/initializers/technologies.utils.php');
     include($includePath . './utils/modifiers/calculateMoraleModifiers.utils.php');
     include($includePath . './utils/missions.utils.php');
 

--- a/modules/flights/utils/initializers/index.php
+++ b/modules/flights/utils/initializers/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/flights/utils/initializers/technologies.utils.php
+++ b/modules/flights/utils/initializers/technologies.utils.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Initializers;
+
+use UniEngine\Engine\Includes\Helpers\World\Elements;
+
+/**
+ * @param array $params
+ * @param array $params['user']
+ */
+function initCombatTechnologiesMap($params) {
+    global $_Vars_ElementCategories;
+
+    $user = $params['user'];
+    $planet = [];
+
+    $technologiesMap = [];
+
+    foreach ($_Vars_ElementCategories['techPurpose']['combat'] as $elementID) {
+        $technologiesMap[$elementID] = Elements\getElementState($elementID, $planet, $user)['level'];
+    }
+
+    return $technologiesMap;
+}
+
+?>


### PR DESCRIPTION
## Summary:

Currently there are several places where user technologies are prepared for combat calculation. All of that duplication should be merged into one shared utility.

## Changelog:

- [x] Extract user technologies initialization function
- [x] Use the new tech initialization functions in attacks handling functions:
    - [x] Regular attack
    - [x] Group attack (ACS)
    - [x] Moon destruction

## Related issues or PRs:

- #91 
