### PR TITLE
Refactor fleet missions' code | Part 06 | User stats aggregation

### DIFF
--- a/includes/functions/FlyingFleetHandler.php
+++ b/includes/functions/FlyingFleetHandler.php
@@ -8,18 +8,7 @@ function FlyingFleetHandler(&$planet, $IncludeFleetsFromEndIDs = array())
 
     if(!empty($_BenchTool)){ $_BenchTool->simpleCountStart(false, 'telemetry__f0'); }
 
-    $UserStatsPattern = array
-    (
-        'raids_won'                    => '0',
-        'raids_draw'                => '0',
-        'raids_lost'                => '0',
-        'raids_acs_won'                => '0',
-        'raids_inAlly'                => '0',
-        'raids_missileAttack'        => '0',
-        'moons_destroyed'            => '0',
-        'moons_created'                => '0',
-        'other_expeditions_count'    => '0',
-    );
+    $UserStatsPattern = UniEngine\Engine\Modules\Flights\Utils\Initializers\initUserStatsMap();
 
     $FleetArchive_Fields = array
     (
@@ -42,12 +31,10 @@ function FlyingFleetHandler(&$planet, $IncludeFleetsFromEndIDs = array())
     {
         $ThisKey1 = 'destroyed_'.$ElementID;
         $CreateAchievementKeys[] = "`{$ThisKey1}`";
-        $UserStatsPattern[$ThisKey1] = '0';
         $UserStatsUpQuery[] = "`{$ThisKey1}` = `{$ThisKey1}` + VALUES(`{$ThisKey1}`)";
 
         $ThisKey2 = 'lost_'.$ElementID;
         $CreateAchievementKeys[] = "`{$ThisKey2}`";
-        $UserStatsPattern[$ThisKey2] = '0';
         $UserStatsUpQuery[] = "`{$ThisKey2}` = `{$ThisKey2}` + VALUES(`{$ThisKey2}`)";
     }
     foreach($_Vars_ElementCategories['defense'] as $ElementID)
@@ -59,12 +46,10 @@ function FlyingFleetHandler(&$planet, $IncludeFleetsFromEndIDs = array())
         }
         $ThisKey1 = 'destroyed_'.$ElementID;
         $CreateAchievementKeys[] = "`{$ThisKey1}`";
-        $UserStatsPattern[$ThisKey1] = '0';
         $UserStatsUpQuery[] = "`{$ThisKey1}` = `{$ThisKey1}` + VALUES(`{$ThisKey1}`)";
 
         $ThisKey2 = 'lost_'.$ElementID;
         $CreateAchievementKeys[] = "`{$ThisKey2}`";
-        $UserStatsPattern[$ThisKey2] = '0';
         $UserStatsUpQuery[] = "`{$ThisKey2}` = `{$ThisKey2}` + VALUES(`{$ThisKey2}`)";
     }
     $CreateAchievementKeys = implode(', ', $CreateAchievementKeys);

--- a/includes/functions/FlyingFleetHandler.php
+++ b/includes/functions/FlyingFleetHandler.php
@@ -2,13 +2,11 @@
 
 function FlyingFleetHandler(&$planet, $IncludeFleetsFromEndIDs = array())
 {
-    global $_EnginePath, $UserStatsPattern, $UserStatsData, $ChangeCoordinatesForFleets, $_Vars_ElementCategories, $_BenchTool, $_Cache, $_GalaxyRow;;
+    global $_EnginePath, $UserStatsData, $ChangeCoordinatesForFleets, $_Vars_ElementCategories, $_BenchTool, $_Cache, $_GalaxyRow;;
 
     include($_EnginePath . 'modules/flights/_includes.php');
 
     if(!empty($_BenchTool)){ $_BenchTool->simpleCountStart(false, 'telemetry__f0'); }
-
-    $UserStatsPattern = UniEngine\Engine\Modules\Flights\Utils\Initializers\initUserStatsMap();
 
     $FleetArchive_Fields = array
     (

--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -931,52 +931,16 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
             }
 
             // Update User Destroyed & Lost Stats
-            if(!empty($ShotDown))
-            {
-                foreach($ShotDown as $ThisType => $ThisData)
-                {
-                    foreach($ThisData as $ThisType2 => $ThisData2)
-                    {
-                        if($ThisType2 == 'd')
-                        {
-                            $ThisKey = 'destroyed_';
-                        }
-                        else
-                        {
-                            $ThisKey = 'lost_';
-                        }
-                        foreach($ThisData2 as $UserID => $DestShips)
-                        {
-                            if($UserID == 0)
-                            {
-                                if($ThisType == 'atk')
-                                {
-                                    $ThisUserID = $FleetRow['fleet_owner'];
-                                }
-                                else
-                                {
-                                    $ThisUserID = $TargetUser['id'];
-                                }
-                            }
-                            else
-                            {
-                                if($ThisType == 'atk')
-                                {
-                                    $ThisUserID = $AttackingFleetOwners[$AttackingFleetID[$UserID]];
-                                }
-                                else
-                                {
-                                    $ThisUserID = $DefendingFleetOwners[$DefendingFleetID[$UserID]];
-                                }
-                            }
-                            foreach($DestShips as $ShipID => $ShipCount)
-                            {
-                                $UserStatsData[$ThisUserID][$ThisKey.$ShipID] += $ShipCount;
-                            }
-                        }
-                    }
-                }
-            }
+            Flights\Utils\FleetCache\applyCombatUnitStats([
+                'userStats' => &$UserStatsData,
+                'combatShotdownResult' => $ShotDown,
+                'mainAttackerUserID' => $FleetRow['fleet_owner'],
+                'mainDefenderUserID' => $TargetUser['id'],
+                'attackingFleetIDs' => [],
+                'attackingFleetOwnerIDs' => [],
+                'defendingFleetIDs' => $DefendingFleetID,
+                'defendingFleetOwnerIDs' => $DefendingFleetOwners,
+            ]);
 
             if(!empty($ShotDown))
             {

--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -4,7 +4,7 @@ use UniEngine\Engine\Modules\Flights;
 
 function MissionCaseAttack($FleetRow, &$_FleetCache)
 {
-    global    $_EnginePath, $_Vars_Prices, $_Lang, $_Vars_GameElements, $_Vars_ElementCategories, $_GameConfig, $UserStatsPattern, $UserStatsData, $UserDev_Log, $IncludeCombatEngine,
+    global    $_EnginePath, $_Vars_Prices, $_Lang, $_Vars_GameElements, $_Vars_ElementCategories, $_GameConfig, $UserStatsData, $UserDev_Log, $IncludeCombatEngine,
             $HPQ_PlanetUpdatedFields;
 
     $Return = array();
@@ -212,18 +212,14 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
             }
         }
 
-        foreach($AttackersIDs as $ID)
-        {
-            if(empty($UserStatsData[$ID]))
-            {
-                $UserStatsData[$ID] = $UserStatsPattern;
+        foreach ($AttackersIDs as $userID) {
+            if (empty($UserStatsData[$userID])) {
+                $UserStatsData[$userID] = Flights\Utils\Initializers\initUserStatsMap();
             }
         }
-        foreach($DefendersIDs as $ID)
-        {
-            if(empty($UserStatsData[$ID]))
-            {
-                $UserStatsData[$ID] = $UserStatsPattern;
+        foreach ($DefendersIDs as $userID) {
+            if (empty($UserStatsData[$userID])) {
+                $UserStatsData[$userID] = Flights\Utils\Initializers\initUserStatsMap();
             }
         }
 

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -5,7 +5,7 @@ use UniEngine\Engine\Modules\Flights;
 function MissionCaseDestruction($FleetRow, &$_FleetCache)
 {
     global    $_EnginePath, $_User, $_Vars_Prices, $_Lang, $_Vars_GameElements, $_Vars_ElementCategories, $_GameConfig, $ChangeCoordinatesForFleets,
-            $UserStatsPattern, $UserStatsData, $UserDev_Log, $IncludeCombatEngine, $HPQ_PlanetUpdatedFields, $GlobalParsedTasks;
+            $UserStatsData, $UserDev_Log, $IncludeCombatEngine, $HPQ_PlanetUpdatedFields, $GlobalParsedTasks;
 
     $Return = array();
     $FleetDestroyedByMoon = false;
@@ -219,18 +219,14 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
             }
         }
 
-        foreach($AttackersIDs as $ID)
-        {
-            if(empty($UserStatsData[$ID]))
-            {
-                $UserStatsData[$ID] = $UserStatsPattern;
+        foreach ($AttackersIDs as $userID) {
+            if (empty($UserStatsData[$userID])) {
+                $UserStatsData[$userID] = Flights\Utils\Initializers\initUserStatsMap();
             }
         }
-        foreach($DefendersIDs as $ID)
-        {
-            if(empty($UserStatsData[$ID]))
-            {
-                $UserStatsData[$ID] = $UserStatsPattern;
+        foreach ($DefendersIDs as $userID) {
+            if (empty($UserStatsData[$userID])) {
+                $UserStatsData[$userID] = Flights\Utils\Initializers\initUserStatsMap();
             }
         }
 

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -1102,52 +1102,16 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
             }
 
             // Update User Destroyed & Lost Stats
-            if(!empty($ShotDown))
-            {
-                foreach($ShotDown as $ThisType => $ThisData)
-                {
-                    foreach($ThisData as $ThisType2 => $ThisData2)
-                    {
-                        if($ThisType2 == 'd')
-                        {
-                            $ThisKey = 'destroyed_';
-                        }
-                        else
-                        {
-                            $ThisKey = 'lost_';
-                        }
-                        foreach($ThisData2 as $UserID => $DestShips)
-                        {
-                            if($UserID == 0)
-                            {
-                                if($ThisType == 'atk')
-                                {
-                                    $ThisUserID = $FleetRow['fleet_owner'];
-                                }
-                                else
-                                {
-                                    $ThisUserID = $TargetUser['id'];
-                                }
-                            }
-                            else
-                            {
-                                if($ThisType == 'atk')
-                                {
-                                    $ThisUserID = $AttackingFleetOwners[$AttackingFleetID[$UserID]];
-                                }
-                                else
-                                {
-                                    $ThisUserID = $DefendingFleetOwners[$DefendingFleetID[$UserID]];
-                                }
-                            }
-                            foreach($DestShips as $ShipID => $ShipCount)
-                            {
-                                $UserStatsData[$ThisUserID][$ThisKey.$ShipID] += $ShipCount;
-                            }
-                        }
-                    }
-                }
-            }
+            Flights\Utils\FleetCache\applyCombatUnitStats([
+                'userStats' => &$UserStatsData,
+                'combatShotdownResult' => $ShotDown,
+                'mainAttackerUserID' => $FleetRow['fleet_owner'],
+                'mainDefenderUserID' => $TargetUser['id'],
+                'attackingFleetIDs' => [],
+                'attackingFleetOwnerIDs' => [],
+                'defendingFleetIDs' => $DefendingFleetID,
+                'defendingFleetOwnerIDs' => $DefendingFleetOwners,
+            ]);
 
             if(!empty($ShotDown))
             {

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -510,6 +510,22 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                         $Return['FleetArchive'][$FleetRow['fleet_id']]['Fleet_End_Res_Metal'] = 0;
                         $Return['FleetArchive'][$FleetRow['fleet_id']]['Fleet_End_Res_Crystal'] = 0;
                         $Return['FleetArchive'][$FleetRow['fleet_id']]['Fleet_End_Res_Deuterium'] = 0;
+
+                        foreach ($AttackingFleets[0] as $elementID => $elementOriginalCount) {
+                            $elementShotDownCount = (
+                                isset($ShotDown['atk']['l'][0][$elementID]) ?
+                                $ShotDown['atk']['l'][0][$elementID] :
+                                0
+                            );
+
+                            Flights\Utils\FleetCache\incrementUserStatsWorldElementCounter([
+                                'userStats' => &$UserStatsData,
+                                'userID' => $FleetRow['fleet_owner'],
+                                'elementID' => $elementID,
+                                'elementCount' => ($elementOriginalCount - $elementShotDownCount),
+                                'counterType' => Flights\Utils\FleetCache\WorldElementCounterType::ElementLost,
+                            ]);
+                        }
                     }
                 }
                 else

--- a/includes/functions/MissionCaseExpedition.php
+++ b/includes/functions/MissionCaseExpedition.php
@@ -8,9 +8,11 @@
 // Before using it, make sure that it's fully compatible with FleetHandler function
 // -------------------------------------------
 
+use UniEngine\Engine\Modules\Flights;
+
 function MissionCaseExpedition($FleetRow)
 {
-    global $_Lang, $_Vars_Prices, $enforceSQLUpdate, $FleetArchivePattern, $UserStatsPattern, $UserStatsData;
+    global $_Lang, $_Vars_Prices, $enforceSQLUpdate, $FleetArchivePattern, $UserStatsData;
 
     $FleetOwner = $FleetRow['fleet_owner'];
     $MessSender = '003';
@@ -27,9 +29,8 @@ function MissionCaseExpedition($FleetRow)
         if($FleetRow['fleet_end_stay'] < time())
         {
             // Update user stats
-            if(empty($UserStatsData[$FleetOwner]))
-            {
-                $UserStatsData[$FleetOwner] = $UserStatsPattern;
+            if (empty($UserStatsData[$FleetOwner])) {
+                $UserStatsData[$FleetOwner] = Flights\Utils\Initializers\initUserStatsMap();
             }
             $UserStatsData[$FleetOwner]['other_expeditions_count'] += 1;
 

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -4,7 +4,7 @@ use UniEngine\Engine\Modules\Flights;
 
 function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
 {
-    global    $_EnginePath, $_Vars_Prices, $_Lang, $_Vars_GameElements, $_Vars_ElementCategories, $_GameConfig, $UserStatsPattern, $UserStatsData, $UserDev_Log, $IncludeCombatEngine,
+    global    $_EnginePath, $_Vars_Prices, $_Lang, $_Vars_GameElements, $_Vars_ElementCategories, $_GameConfig, $UserStatsData, $UserDev_Log, $IncludeCombatEngine,
             $HPQ_PlanetUpdatedFields;
 
     $Return = array();
@@ -316,18 +316,14 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
             }
         }
 
-        foreach($AttackersIDs as $ID)
-        {
-            if(empty($UserStatsData[$ID]))
-            {
-                $UserStatsData[$ID] = $UserStatsPattern;
+        foreach ($AttackersIDs as $userID) {
+            if (empty($UserStatsData[$userID])) {
+                $UserStatsData[$userID] = Flights\Utils\Initializers\initUserStatsMap();
             }
         }
-        foreach($DefendersIDs as $ID)
-        {
-            if(empty($UserStatsData[$ID]))
-            {
-                $UserStatsData[$ID] = $UserStatsPattern;
+        foreach ($DefendersIDs as $userID) {
+            if (empty($UserStatsData[$userID])) {
+                $UserStatsData[$userID] = Flights\Utils\Initializers\initUserStatsMap();
             }
         }
 

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -1239,52 +1239,16 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
             }
 
             // Update User Destroyed & Lost Stats
-            if(!empty($ShotDown))
-            {
-                foreach($ShotDown as $ThisType => $ThisData)
-                {
-                    foreach($ThisData as $ThisType2 => $ThisData2)
-                    {
-                        if($ThisType2 == 'd')
-                        {
-                            $ThisKey = 'destroyed_';
-                        }
-                        else
-                        {
-                            $ThisKey = 'lost_';
-                        }
-                        foreach($ThisData2 as $UserID => $DestShips)
-                        {
-                            if($UserID == 0)
-                            {
-                                if($ThisType == 'atk')
-                                {
-                                    $ThisUserID = $FleetRow['fleet_owner'];
-                                }
-                                else
-                                {
-                                    $ThisUserID = $TargetUser['id'];
-                                }
-                            }
-                            else
-                            {
-                                if($ThisType == 'atk')
-                                {
-                                    $ThisUserID = $AttackingFleetOwners[$AttackingFleetID[$UserID]];
-                                }
-                                else
-                                {
-                                    $ThisUserID = $DefendingFleetOwners[$DefendingFleetID[$UserID]];
-                                }
-                            }
-                            foreach($DestShips as $ShipID => $ShipCount)
-                            {
-                                $UserStatsData[$ThisUserID][$ThisKey.$ShipID] += $ShipCount;
-                            }
-                        }
-                    }
-                }
-            }
+            Flights\Utils\FleetCache\applyCombatUnitStats([
+                'userStats' => &$UserStatsData,
+                'combatShotdownResult' => $ShotDown,
+                'mainAttackerUserID' => $FleetRow['fleet_owner'],
+                'mainDefenderUserID' => $TargetUser['id'],
+                'attackingFleetIDs' => $AttackingFleetID,
+                'attackingFleetOwnerIDs' => $AttackingFleetOwners,
+                'defendingFleetIDs' => $DefendingFleetID,
+                'defendingFleetOwnerIDs' => $DefendingFleetOwners,
+            ]);
 
             $DestroyedDefendersShips_TotalPrice = 0;
             if(!empty($ShotDown['atk']['d']))

--- a/includes/functions/MissionCaseMIP.php
+++ b/includes/functions/MissionCaseMIP.php
@@ -54,7 +54,7 @@ function MissionCaseMIP($FleetRow, &$_FleetCache)
         }
 
         if (empty($UserStatsData[$FleetRow['fleet_owner']])) {
-            $UserStatsData[$FleetRow['fleet_owner']] = Flights\Utils\Initializers\initUserStatsMap();;
+            $UserStatsData[$FleetRow['fleet_owner']] = Flights\Utils\Initializers\initUserStatsMap();
         }
         if(!$IsAllyFight)
         {

--- a/includes/functions/MissionCaseMIP.php
+++ b/includes/functions/MissionCaseMIP.php
@@ -1,8 +1,10 @@
 <?php
 
+use UniEngine\Engine\Modules\Flights;
+
 function MissionCaseMIP($FleetRow, &$_FleetCache)
 {
-    global $_EnginePath, $_Lang, $_Vars_GameElements, $_Vars_ElementCategories, $UserStatsPattern, $UserStatsData, $UserDev_Log, $HPQ_PlanetUpdatedFields;
+    global $_EnginePath, $_Lang, $_Vars_GameElements, $_Vars_ElementCategories, $UserStatsData, $UserDev_Log, $HPQ_PlanetUpdatedFields;
     static $FunctionIncluded = false;
 
     $Return = array();
@@ -51,9 +53,8 @@ function MissionCaseMIP($FleetRow, &$_FleetCache)
             }
         }
 
-        if(empty($UserStatsData[$FleetRow['fleet_owner']]))
-        {
-            $UserStatsData[$FleetRow['fleet_owner']] = $UserStatsPattern;
+        if (empty($UserStatsData[$FleetRow['fleet_owner']])) {
+            $UserStatsData[$FleetRow['fleet_owner']] = Flights\Utils\Initializers\initUserStatsMap();;
         }
         if(!$IsAllyFight)
         {
@@ -201,9 +202,8 @@ function MissionCaseMIP($FleetRow, &$_FleetCache)
                                 $AttackerReport[] = '{MIP_destroy}';
                                 $DefenderReport[] = '{MIP_destroy}';
 
-                                if(empty($UserStatsData[$TargetPlanet['id_owner']]))
-                                {
-                                    $UserStatsData[$TargetPlanet['id_owner']] = $UserStatsPattern;
+                                if (empty($UserStatsData[$TargetPlanet['id_owner']])) {
+                                    $UserStatsData[$TargetPlanet['id_owner']] = Flights\Utils\Initializers\initUserStatsMap();
                                 }
                             }
                             $CreateThisLine = '&bull; '.$_Lang['tech'][$key].' <b>( -'.prettyNumber($val).')</b> ['.prettyNumber($Attack['LeftDefs'][$key]).'/'.prettyNumber($Attack['LeftDefs'][$key] + $val).']';

--- a/includes/functions/MissionCaseSpy.php
+++ b/includes/functions/MissionCaseSpy.php
@@ -1,8 +1,10 @@
 <?php
 
+use UniEngine\Engine\Modules\Flights;
+
 function MissionCaseSpy($FleetRow, &$_FleetCache)
 {
-    global    $_Lang, $_Vars_Prices, $_GameConfig, $_EnginePath, $UserStatsPattern, $UserStatsData, $UserDev_Log,
+    global    $_Lang, $_Vars_Prices, $_GameConfig, $_EnginePath, $UserStatsData, $UserDev_Log,
             $_User, $GlobalParsedTasks;
     static    $SpyTargetIncluded = false;
 
@@ -327,13 +329,11 @@ function MissionCaseSpy($FleetRow, &$_FleetCache)
             {
                 if($FleetRow['ally_id'] == 0 OR ($TargetUser['ally_id'] != $FleetRow['ally_id']))
                 {
-                    if(empty($UserStatsData[$FleetRow['fleet_owner']]))
-                    {
-                        $UserStatsData[$FleetRow['fleet_owner']] = $UserStatsPattern;
+                    if (empty($UserStatsData[$FleetRow['fleet_owner']])) {
+                        $UserStatsData[$FleetRow['fleet_owner']] = Flights\Utils\Initializers\initUserStatsMap();
                     }
-                    if(empty($UserStatsData[$TargetPlanet['id_owner']]))
-                    {
-                        $UserStatsData[$TargetPlanet['id_owner']] = $UserStatsPattern;
+                    if (empty($UserStatsData[$TargetPlanet['id_owner']])) {
+                        $UserStatsData[$TargetPlanet['id_owner']] = Flights\Utils\Initializers\initUserStatsMap();
                     }
                     $UserStatsData[$FleetRow['fleet_owner']]['lost_210'] += $ShipsCount;
                     $UserStatsData[$TargetPlanet['id_owner']]['destroyed_210'] += $ShipsCount;

--- a/includes/helpers/world/elements.common.functions.php
+++ b/includes/helpers/world/elements.common.functions.php
@@ -22,16 +22,19 @@ function isShip($elementID) {
     return in_array($elementID, $_Vars_ElementCategories['fleet']);
 }
 
-function isDefenseSystem($elementID) {
-    global $_Vars_ElementCategories;
-
-    return in_array($elementID, $_Vars_ElementCategories['defense']);
-}
-
 function isMissile($elementID) {
     global $_Vars_ElementCategories;
 
     return in_array($elementID, $_Vars_ElementCategories['rockets']);
+}
+
+function isDefenseSystem($elementID) {
+    global $_Vars_ElementCategories;
+
+    return (
+        in_array($elementID, $_Vars_ElementCategories['defense']) &&
+        !isMissile($elementID)
+    );
 }
 
 function isStructureAvailableOnPlanetType($elementID, $planetType) {

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -9,6 +9,7 @@ call_user_func(function () {
     include($includePath . './utils/calculations/calculatePillageFactor.utils.php');
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');
+    include($includePath . './utils/fleetCache/updateUserStats.utils.php');
     include($includePath . './utils/initializers/technologies.utils.php');
     include($includePath . './utils/initializers/userStats.utils.php');
     include($includePath . './utils/modifiers/calculateMoraleModifiers.utils.php');

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -10,6 +10,7 @@ call_user_func(function () {
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');
     include($includePath . './utils/initializers/technologies.utils.php');
+    include($includePath . './utils/initializers/userStats.utils.php');
     include($includePath . './utils/modifiers/calculateMoraleModifiers.utils.php');
     include($includePath . './utils/missions.utils.php');
 

--- a/modules/flights/utils/calculations/calculateResourcesLoss.utils.php
+++ b/modules/flights/utils/calculations/calculateResourcesLoss.utils.php
@@ -39,7 +39,8 @@ function calculateResourcesLoss($params) {
     foreach ($unitsLost as $unitID => $unitAmount) {
         if (
             !Elements\isShip($unitID) &&
-            !Elements\isDefenseSystem($unitID)
+            !Elements\isDefenseSystem($unitID) &&
+            !Elements\isMissile($unitID)
         ) {
             continue;
         }

--- a/modules/flights/utils/fleetCache/updateUserStats.utils.php
+++ b/modules/flights/utils/fleetCache/updateUserStats.utils.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\FleetCache;
+
+use UniEngine\Engine\Includes\Helpers\World\Elements;
+
+abstract class WorldElementCounterType {
+    const ElementDestroyed = 0;
+    const ElementLost = 1;
+}
+
+/**
+ * @param array $params
+ * @param &array $params['userStats']
+ * @param string $params['userID']
+ * @param number $params['elementID']
+ * @param number $params['elementCount']
+ * @param WorldElementCounterType $params['counterType']
+ */
+function incrementUserStatsWorldElementCounter($params) {
+    $elementID = $params['elementID'];
+
+    if (
+        !Elements\isShip($elementID) &&
+        !Elements\isDefenseSystem($elementID)
+    ) {
+        return;
+    }
+
+    $entryKey = (
+        $params['counterType'] === WorldElementCounterType::ElementDestroyed ?
+        "destroyed_{$elementID}" :
+        "lost_{$elementID}"
+    );
+
+    _incrementUserStatsEntry(
+        $params['userStats'],
+        $params['userID'],
+        $entryKey,
+        $params['elementCount']
+    );
+}
+
+function _incrementUserStatsEntry(
+    &$userStatsObj,
+    $userID,
+    $entryKey,
+    $incrementValue
+) {
+    $userStatsObj[$userID][$entryKey] += $incrementValue;
+}
+
+?>

--- a/modules/flights/utils/initializers/userStats.utils.php
+++ b/modules/flights/utils/initializers/userStats.utils.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Initializers;
+
+use UniEngine\Engine\Includes\Helpers\World\Elements;
+
+/**
+ * @see FlyingFleetHandler.php
+ * (this function must generate elements in the same order as keys in the stats updating query!)
+ */
+function initUserStatsMap() {
+    global $_Vars_ElementCategories;
+
+    $userStatsMap = [
+        'raids_won'                 => '0',
+        'raids_draw'                => '0',
+        'raids_lost'                => '0',
+        'raids_acs_won'             => '0',
+        'raids_inAlly'              => '0',
+        'raids_missileAttack'       => '0',
+        'moons_destroyed'           => '0',
+        'moons_created'             => '0',
+        'other_expeditions_count'   => '0',
+    ];
+
+    foreach ([ 'fleet', 'defense' ] as $elementCategory) {
+        foreach ($_Vars_ElementCategories[$elementCategory] as $elementID) {
+            if (
+                !Elements\isShip($elementID) &&
+                !Elements\isDefenseSystem($elementID)
+            ) {
+                continue;
+            }
+
+            $unitsDestroyedKey = "destroyed_{$elementID}";
+            $unitsLostKey = "lost_{$elementID}";
+
+            $userStatsMap[$unitsDestroyedKey] = '0';
+            $userStatsMap[$unitsLostKey] = '0';
+        }
+    }
+
+    return $userStatsMap;
+}
+
+?>


### PR DESCRIPTION
## Summary:

Currently there are several places where combat statistics (units destroyed & lost) are being parsed and stored in objects. What is more, some of the operations use internal structure keys, which should be hidden by some sort of abstraction when incrementing the structure. All of that duplication should be merged into shared utilities and abstracted away where needed.

## Changelog:

- [x] Create abstractions for user stats operations (eg. increments)
- [x] Extract combat statistics data aggregation utilities
- [x] Use the new user stats abstractions & aggregators in attacks handling functions:
    - [x] Regular attack
    - [x] Group attack (ACS)
    - [x] Moon destruction
- [x] Bugfix: when moon destruction destroyed the attacking fleet, all destroyed ships should be counted as "lost" by the attacking player (however, not "destroyed" by the defender; one could say that "nature" got the kills)

## Related issues or PRs:

- #91 
