### PR TITLE
Refactor fleet missions' code | Part 07 | Post-combat fleet updates

### DIFF
--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -280,16 +280,10 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
 
         $QryUpdateFleets = [];
         $UserDev_UpFl = [];
-
-        $UserDev_UpFl[$FleetRow['fleet_id']] = Flights\Utils\Factories\createFleetDevelopmentLogEntries([
-            'originalShips' => $AttackingFleets[0],
-            'postCombatShips' => $AtkShips[0],
-        ]);
+        $resourcesPillage = null;
 
         // Parse result data - attacker fleet
         if (!empty($AtkShips[0])) {
-            $resourcesPillage = null;
-
             if ($Result === COMBAT_ATK) {
                 $fleetPillageStorage = Flights\Utils\Calculations\calculatePillageStorage([
                     'fleetRow' => $FleetRow,
@@ -318,15 +312,12 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                     $StolenDeu = $resourcesPillage['deuterium'];
 
                     if ($StolenMet > 0) {
-                        $UserDev_UpFl[$FleetRow['fleet_id']][] = 'M,'.$StolenMet;
                         $TriggerTasksCheck['BATTLE_COLLECT_METAL'] = $StolenMet;
                     }
                     if ($StolenCry > 0) {
-                        $UserDev_UpFl[$FleetRow['fleet_id']][] = 'C,'.$StolenCry;
                         $TriggerTasksCheck['BATTLE_COLLECT_CRYSTAL'] = $StolenCry;
                     }
                     if ($StolenDeu > 0) {
-                        $UserDev_UpFl[$FleetRow['fleet_id']][] = 'D,'.$StolenDeu;
                         $TriggerTasksCheck['BATTLE_COLLECT_DEUTERIUM'] = $StolenDeu;
                     }
 
@@ -346,6 +337,12 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
         } else {
             $DeleteFleet[] = $FleetRow['fleet_id'];
         }
+
+        $UserDev_UpFl[$FleetRow['fleet_id']] = Flights\Utils\Factories\createFleetDevelopmentLogEntries([
+            'originalShips' => $AttackingFleets[0],
+            'postCombatShips' => $AtkShips[0],
+            'resourcesPillage' => $resourcesPillage,
+        ]);
 
         // Parse result data - Defenders
         $i = 1;

--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -278,7 +278,6 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
         $DefSysLost        = $Combat['DefSysLost'];
         $ShotDown        = $Combat['ShotDown'];
 
-        $FleetStorage = 0;
         // Parse result data - attacker fleet
         if(!empty($AtkShips[0]))
         {
@@ -294,10 +293,6 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                     }
                     $QryUpdateFleets[0]['array'][] = "{$ID},{$Count}";
                     $QryUpdateFleets[0]['count'] += $Count;
-                }
-                if($Result === COMBAT_ATK && (!isset($_Vars_Prices[$ID]['cantPillage']) || $_Vars_Prices[$ID]['cantPillage'] !== true))
-                {
-                    $FleetStorage += $_Vars_Prices[$ID]['capacity'] * $Count;
                 }
 
                 if($Count < $AttackingFleets[0][$ID])
@@ -325,12 +320,12 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
 
             if($Result === COMBAT_ATK)
             {
-                $FleetStorage -= $FleetRow['fleet_resource_metal'];
-                $FleetStorage -= $FleetRow['fleet_resource_crystal'];
-                $FleetStorage -= $FleetRow['fleet_resource_deuterium'];
+                $fleetPillageStorage = Flights\Utils\Calculations\calculatePillageStorage([
+                    'fleetRow' => $FleetRow,
+                    'ships' => $AtkShips[0],
+                ]);
 
-                if($FleetStorage > 0)
-                {
+                if ($fleetPillageStorage > 0) {
                     $pillageFactor = Flights\Utils\Calculations\calculatePillageFactor([
                         'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
                         'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
@@ -344,7 +339,7 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                             'planet' => $TargetPlanet,
                             'maxPillagePercentage' => $pillageFactor,
                         ]),
-                        'fleetTotalStorage' => $FleetStorage,
+                        'fleetTotalStorage' => $fleetPillageStorage,
                     ]);
 
                     $StolenMet = $resourcesPillage['metal'];

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -286,8 +286,6 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
         $DefSysLost        = $Combat['DefSysLost'];
         $ShotDown        = $Combat['ShotDown'];
 
-        $FleetStorage = 0;
-
         // Parse result data - attacker fleet
         if(!empty($AtkShips[0]))
         {
@@ -307,10 +305,6 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                     }
                     $QryUpdateFleets[0]['array'][] = "{$ID},{$Count}";
                     $QryUpdateFleets[0]['count'] += $Count;
-                }
-                if($Result === COMBAT_ATK && (!isset($_Vars_Prices[$ID]['cantPillage']) || $_Vars_Prices[$ID]['cantPillage'] !== true))
-                {
-                    $FleetStorage += $_Vars_Prices[$ID]['capacity'] * $Count;
                 }
 
                 if($Count < $AttackingFleets[0][$ID])
@@ -338,12 +332,12 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
 
             if($Result === COMBAT_ATK)
             {
-                $FleetStorage -= $FleetRow['fleet_resource_metal'];
-                $FleetStorage -= $FleetRow['fleet_resource_crystal'];
-                $FleetStorage -= $FleetRow['fleet_resource_deuterium'];
+                $fleetPillageStorage = Flights\Utils\Calculations\calculatePillageStorage([
+                    'fleetRow' => $FleetRow,
+                    'ships' => $AtkShips[0],
+                ]);
 
-                if($FleetStorage > 0)
-                {
+                if ($fleetPillageStorage > 0) {
                     $pillageFactor = Flights\Utils\Calculations\calculatePillageFactor([
                         'mainAttackerMoraleLevel' => $FleetRow['morale_level'],
                         'mainDefenderMoraleLevel' => $TargetUser['morale_level'],
@@ -357,7 +351,7 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                             'planet' => $TargetPlanet,
                             'maxPillagePercentage' => $pillageFactor,
                         ]),
-                        'fleetTotalStorage' => $FleetStorage,
+                        'fleetTotalStorage' => $fleetPillageStorage,
                     ]);
 
                     $StolenMet = $resourcesPillage['metal'];

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -286,48 +286,26 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
         $DefSysLost        = $Combat['DefSysLost'];
         $ShotDown        = $Combat['ShotDown'];
 
+        $QryUpdateFleets = [];
+
         // Parse result data - attacker fleet
-        if(!empty($AtkShips[0]))
-        {
-            $QryUpdateFleets[0]['id'] = $FleetRow['fleet_id'];
+        if (!empty($AtkShips[0])) {
+            $resourcesPillage = null;
+
             foreach($AtkShips[0] as $ID => $Count)
             {
-                $QryUpdateFleets[0]['mess'] = '1';
                 if($Count > 0)
                 {
                     if($ID == 214)
                     {
                         $ThisDeathStarCount = $Count;
                     }
-                    if(!isset($QryUpdateFleets[0]['count']))
-                    {
-                        $QryUpdateFleets[0]['count'] = 0;
-                    }
-                    $QryUpdateFleets[0]['array'][] = "{$ID},{$Count}";
-                    $QryUpdateFleets[0]['count'] += $Count;
                 }
 
                 if($Count < $AttackingFleets[0][$ID])
                 {
                     $UserDev_UpFl[$FleetRow['fleet_id']][] = $ID.','.($AttackingFleets[0][$ID] - $Count);
                 }
-            }
-
-            foreach($AttackingFleets[0] as $ID => $Count)
-            {
-                $Difference = $Count;
-                if(isset($AtkShips[0][$ID]))
-                {
-                    $Difference -= $AtkShips[0][$ID];
-                }
-                if($Difference > 0)
-                {
-                    $QryUpdateFleets[0]['array_lost'][] = "{$ID},{$Difference}";
-                }
-            }
-            if(!empty($QryUpdateFleets[0]['array_lost']))
-            {
-                $QryUpdateFleets[0]['array_lost'] = implode(';', $QryUpdateFleets[0]['array_lost']);
             }
 
             if($Result === COMBAT_ATK)
@@ -370,10 +348,6 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                         $UserDev_UpFl[$FleetRow['fleet_id']][] = 'D,'.$StolenDeu;
                         $TriggerTasksCheck['atk']['BATTLE_COLLECT_DEUTERIUM'] = $StolenDeu;
                     }
-
-                    $QryUpdateFleets[0]['metal'] = $StolenMet;
-                    $QryUpdateFleets[0]['crystal'] = $StolenCry;
-                    $QryUpdateFleets[0]['deuterium'] = $StolenDeu;
 
                     $Return['FleetArchive'][$FleetRow['fleet_id']]['Fleet_End_Res_Metal'] = $StolenMet;
                     $Return['FleetArchive'][$FleetRow['fleet_id']]['Fleet_End_Res_Crystal'] = $StolenCry;
@@ -527,6 +501,14 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                     $MoonHasBeenDestroyed = -1;
                 }
             }
+
+            $QryUpdateFleets[$FleetRow['fleet_id']] = Flights\Utils\Factories\createFleetUpdateEntry([
+                'fleetID' => $FleetRow['fleet_id'],
+                'state' => '1',
+                'originalShips' => $AttackingFleets[0],
+                'postCombatShips' => $AtkShips[0],
+                'resourcesPillage' => $resourcesPillage,
+            ]);
         }
         else
         {
@@ -591,7 +573,12 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                 }
                 else
                 {
-                    $QryUpdateFleets[$i]['id'] = $DefendingFleetID[$User];
+                    $QryUpdateFleets[$DefendingFleetID[$User]] = Flights\Utils\Factories\createFleetUpdateEntry([
+                        'fleetID' => $DefendingFleetID[$User],
+                        'originalShips' => $Ships,
+                        'postCombatShips' => $DefShips[$User],
+                    ]);
+
                     if(!empty($DefShips[$User]))
                     {
                         foreach($Ships as $ID => $Count)
@@ -599,34 +586,13 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                             $ThisCount = 0;
                             if(!empty($DefShips[$User][$ID]))
                             {
-                                $OldCount = $Count;
-                                $Count = $DefShips[$User][$ID];
-                                $ThisCount = $Count;
-                                if($Count > 0)
-                                {
-                                    if(!isset($QryUpdateFleets[$i]['count']))
-                                    {
-                                        $QryUpdateFleets[$i]['count'] = 0;
-                                    }
-                                    $QryUpdateFleets[$i]['array'][] = "{$ID},{$Count}";
-                                    $QryUpdateFleets[$i]['count'] += $Count;
-                                }
-                                $Difference = $OldCount - $Count;
-                                if($Difference > 0)
-                                {
-                                    $QryUpdateFleets[$i]['array_lost'][] = "{$ID},{$Difference}";
-                                }
+                                $ThisCount = $DefShips[$User][$ID];
                             }
 
                             if($ThisCount < $DefendingFleets[$User][$ID])
                             {
                                 $UserDev_UpFl[$DefendingFleetID[$User]][] = $ID.','.($DefendingFleets[$User][$ID] - $ThisCount);
                             }
-                        }
-
-                        if(!empty($QryUpdateFleets[$i]['array_lost']))
-                        {
-                            $QryUpdateFleets[$i]['array_lost'] = implode(';', $QryUpdateFleets[$i]['array_lost']);
                         }
                     }
                     else
@@ -669,81 +635,67 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
             $_FleetCache['updatePlanets'][$TargetPlanet['id']] = false;
         }
 
-        // Update all fleets (if necessary)
-        if(!empty($QryUpdateFleets))
-        {
-            foreach($QryUpdateFleets as $Data)
-            {
-                if(!empty($Data))
-                {
-                    if($Data['metal'] <= 0)
-                    {
-                        $Data['metal'] = '0';
-                    }
-                    if($Data['crystal'] <= 0)
-                    {
-                        $Data['crystal'] = '0';
-                    }
-                    if($Data['deuterium'] <= 0)
-                    {
-                        $Data['deuterium'] = '0';
+        foreach ($QryUpdateFleets as $fleetUpdateID => $fleetUpdateEntry) {
+            $serializedFleetArray = Array2String($fleetUpdateEntry['fleet_array']);
+            $serializedFleetArrayLost = Array2String($fleetUpdateEntry['fleet_array_lost']);
+
+            if (!empty($fleetUpdateEntry['fleet_array'])) {
+                if (!empty($fleetUpdateEntry['fleet_array_lost'])) {
+                    if (strlen($serializedFleetArray) > strlen($serializedFleetArrayLost)) {
+                        $Return['FleetArchive'][$fleetUpdateID]['Fleet_Array_Changes'] = "\"+D;{$serializedFleetArrayLost}|\"";
+                    } else {
+                        $Return['FleetArchive'][$fleetUpdateID]['Fleet_Array_Changes'] = "\"+L;{$serializedFleetArray}|\"";
                     }
 
-                    if(!empty($Data['array']))
-                    {
-                        $Data['array'] = implode(';', $Data['array']);
-                        if(!empty($Data['array_lost']))
-                        {
-                            if(strlen($Data['array']) > strlen($Data['array_lost']))
-                            {
-                                $Return['FleetArchive'][$Data['id']]['Fleet_Array_Changes'] = "\"+D;{$Data['array_lost']}|\"";
-                            }
-                            else
-                            {
-                                $Return['FleetArchive'][$Data['id']]['Fleet_Array_Changes'] = "\"+L;{$Data['array']}|\"";
-                            }
-                            $Return['FleetArchive'][$Data['id']]['Fleet_Info_HasLostShips'] = '!true';
-                        }
-                        if($Data['id'] != $FleetRow['fleet_id'])
-                        {
-                            $_FleetCache['defFleets'][$FleetRow['fleet_end_id']][$Data['id']]['fleet_array'] = $Data['array'];
-                        }
-                    }
-
-                    if($Data['id'] == $FleetRow['fleet_id'] AND $_FleetCache['fleetRowStatus'][$FleetRow['fleet_id']]['calcCount'] == 2)
-                    {
-                        // Update $_FleetCache, instead of sending additional Query to Update FleetState
-                        // This fleet will be restored in this Calculation, so don't waste our time
-                        $CachePointer = &$_FleetCache['fleetRowUpdate'][$Data['id']];
-                        $CachePointer['fleet_array'] = $Data['array'];
-                        $CachePointer['fleet_resource_metal'] = $FleetRow['fleet_resource_metal'] + $Data['metal'];
-                        $CachePointer['fleet_resource_crystal'] = $FleetRow['fleet_resource_crystal'] + $Data['crystal'];
-                        $CachePointer['fleet_resource_deuterium'] = $FleetRow['fleet_resource_deuterium'] + $Data['deuterium'];
-                    }
-                    else
-                    {
-                        // Create UpdateFleet record for $_FleetCache
-                        $CachePointer = &$_FleetCache['updateFleets'][$Data['id']];
-                        $CachePointer['fleet_array'] = $Data['array'];
-                        $CachePointer['fleet_amount'] = $Data['count'];
-                        $CachePointer['fleet_mess'] = $Data['mess'];
-                        if(!isset($CachePointer['fleet_resource_metal']))
-                        {
-                            $CachePointer['fleet_resource_metal'] = 0;
-                        }
-                        if(!isset($CachePointer['fleet_resource_crystal']))
-                        {
-                            $CachePointer['fleet_resource_crystal'] = 0;
-                        }
-                        if(!isset($CachePointer['fleet_resource_deuterium']))
-                        {
-                            $CachePointer['fleet_resource_deuterium'] = 0;
-                        }
-                        $CachePointer['fleet_resource_metal'] += $Data['metal'];
-                        $CachePointer['fleet_resource_crystal'] += $Data['crystal'];
-                        $CachePointer['fleet_resource_deuterium'] += $Data['deuterium'];
-                    }
+                    $Return['FleetArchive'][$fleetUpdateID]['Fleet_Info_HasLostShips'] = '!true';
                 }
+
+                if ($fleetUpdateID != $FleetRow['fleet_id']) {
+                    $_FleetCache['defFleets'][$FleetRow['fleet_end_id']][$fleetUpdateID]['fleet_array'] = $serializedFleetArray;
+                }
+            }
+
+            if (
+                $fleetUpdateID == $FleetRow['fleet_id'] &&
+                $_FleetCache['fleetRowStatus'][$FleetRow['fleet_id']]['calcCount'] == 2
+            ) {
+                // Update $_FleetCache, instead of sending additional Query to Update FleetState
+                // This fleet will be restored in this Calculation, so don't waste our time
+                $CachePointer = &$_FleetCache['fleetRowUpdate'][$fleetUpdateID];
+                $CachePointer['fleet_array'] = $serializedFleetArray;
+                $CachePointer['fleet_resource_metal'] = (
+                    $FleetRow['fleet_resource_metal'] +
+                    $fleetUpdateEntry['fleet_resource_metal']
+                );
+                $CachePointer['fleet_resource_crystal'] = (
+                    $FleetRow['fleet_resource_crystal'] +
+                    $fleetUpdateEntry['fleet_resource_crystal']
+                );
+                $CachePointer['fleet_resource_deuterium'] = (
+                    $FleetRow['fleet_resource_deuterium'] +
+                    $fleetUpdateEntry['fleet_resource_deuterium']
+                );
+            } else {
+                // Create UpdateFleet record for $_FleetCache
+                $CachePointer = &$_FleetCache['updateFleets'][$fleetUpdateID];
+                $CachePointer['fleet_array'] = $serializedFleetArray;
+                $CachePointer['fleet_amount'] = $fleetUpdateEntry['fleet_amount'];
+                $CachePointer['fleet_mess'] = $fleetUpdateEntry['fleet_mess'];
+                $CachePointer['fleet_resource_metal'] = (
+                    isset($CachePointer['fleet_resource_metal']) ?
+                    $CachePointer['fleet_resource_metal'] + $fleetUpdateEntry['fleet_resource_metal'] :
+                    $fleetUpdateEntry['fleet_resource_metal']
+                );
+                $CachePointer['fleet_resource_crystal'] = (
+                    isset($CachePointer['fleet_resource_crystal']) ?
+                    $CachePointer['fleet_resource_crystal'] + $fleetUpdateEntry['fleet_resource_crystal'] :
+                    $fleetUpdateEntry['fleet_resource_crystal']
+                );
+                $CachePointer['fleet_resource_deuterium'] = (
+                    isset($CachePointer['fleet_resource_deuterium']) ?
+                    $CachePointer['fleet_resource_deuterium'] + $fleetUpdateEntry['fleet_resource_deuterium'] :
+                    $fleetUpdateEntry['fleet_resource_deuterium']
+                );
             }
         }
 

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -290,16 +290,10 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
 
         $QryUpdateFleets = [];
         $UserDev_UpFl = [];
-
-        $UserDev_UpFl[$FleetRow['fleet_id']] = Flights\Utils\Factories\createFleetDevelopmentLogEntries([
-            'originalShips' => $AttackingFleets[0],
-            'postCombatShips' => $AtkShips[0],
-        ]);
+        $resourcesPillage = null;
 
         // Parse result data - attacker fleet
         if (!empty($AtkShips[0])) {
-            $resourcesPillage = null;
-
             $postCombatDeathstarsCount = (
                 isset($AtkShips[0][$DEATHSTAR_ELEMENT_ID]) ?
                     $AtkShips[0][$DEATHSTAR_ELEMENT_ID] :
@@ -334,15 +328,12 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                     $StolenDeu = $resourcesPillage['deuterium'];
 
                     if ($StolenMet > 0) {
-                        $UserDev_UpFl[$FleetRow['fleet_id']][] = 'M,'.$StolenMet;
                         $TriggerTasksCheck['atk']['BATTLE_COLLECT_METAL'] = $StolenMet;
                     }
                     if ($StolenCry > 0) {
-                        $UserDev_UpFl[$FleetRow['fleet_id']][] = 'C,'.$StolenCry;
                         $TriggerTasksCheck['atk']['BATTLE_COLLECT_CRYSTAL'] = $StolenCry;
                     }
                     if ($StolenDeu > 0) {
-                        $UserDev_UpFl[$FleetRow['fleet_id']][] = 'D,'.$StolenDeu;
                         $TriggerTasksCheck['atk']['BATTLE_COLLECT_DEUTERIUM'] = $StolenDeu;
                     }
 
@@ -466,11 +457,6 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
 
                         $DeleteFleet[] = $FleetRow['fleet_id'];
 
-                        $UserDev_UpFl[$FleetRow['fleet_id']] = Flights\Utils\Factories\createFleetDevelopmentLogEntries([
-                            'originalShips' => $AttackingFleets[0],
-                            'postCombatShips' => [],
-                        ]);
-
                         $Return['FleetArchive'][$FleetRow['fleet_id']]['Fleet_End_Res_Metal'] = 0;
                         $Return['FleetArchive'][$FleetRow['fleet_id']]['Fleet_End_Res_Crystal'] = 0;
                         $Return['FleetArchive'][$FleetRow['fleet_id']]['Fleet_End_Res_Deuterium'] = 0;
@@ -510,6 +496,20 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
 
             $FleetHasBeenDestroyed = true;
         }
+
+        $UserDev_UpFl[$FleetRow['fleet_id']] = Flights\Utils\Factories\createFleetDevelopmentLogEntries([
+            'originalShips' => $AttackingFleets[0],
+            'postCombatShips' => (
+                !$FleetHasBeenDestroyed ?
+                $AtkShips[0] :
+                []
+            ),
+            'resourcesPillage' => (
+                !$FleetHasBeenDestroyed ?
+                $resourcesPillage :
+                []
+            ),
+        ]);
 
         // Parse result data - Defenders
         $i = 1;

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -577,7 +577,7 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                         'postCombatShips' => $DefShips[$User],
                     ]);
 
-                    if (!empty($DefShips[$User])) {
+                    if (empty($DefShips[$User])) {
                         $DeleteFleet[] = $DefendingFleetID[$User];
                     }
                 }

--- a/includes/helpers/fleets/functions.php
+++ b/includes/helpers/fleets/functions.php
@@ -18,6 +18,24 @@ function getShipsStorageCapacity($shipID) {
     return $_Vars_Prices[$shipID]['capacity'];
 }
 
+function canShipPillage($shipID) {
+    global $_Vars_Prices;
+
+    return (
+        !isset($_Vars_Prices[$shipID]['cantPillage']) ?
+            true :
+            ($_Vars_Prices[$shipID]['cantPillage'] !== true)
+    );
+}
+
+function getShipsPillageStorageCapacity($shipID) {
+    return (
+        canShipPillage($shipID) ?
+            getShipsStorageCapacity($shipID) :
+            0
+    );
+}
+
 function getShipsUsedEngineData($shipID, $user) {
     $engines = getShipsEngines($shipID);
 

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -6,10 +6,11 @@ call_user_func(function () {
 
     $includePath = $_EnginePath . 'modules/flights/';
 
-    include($includePath . './utils/factories/createFleetUpdateEntry.utils.php');
     include($includePath . './utils/calculations/calculatePillageFactor.utils.php');
     include($includePath . './utils/calculations/calculatePillageStorage.utils.php');
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
+    include($includePath . './utils/factories/createFleetDevelopmentLogEntries.utils.php');
+    include($includePath . './utils/factories/createFleetUpdateEntry.utils.php');
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');
     include($includePath . './utils/fleetCache/updateUserStats.utils.php');
     include($includePath . './utils/initializers/technologies.utils.php');

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -6,6 +6,7 @@ call_user_func(function () {
 
     $includePath = $_EnginePath . 'modules/flights/';
 
+    include($includePath . './utils/factories/createFleetUpdateEntry.utils.php');
     include($includePath . './utils/calculations/calculatePillageFactor.utils.php');
     include($includePath . './utils/calculations/calculatePillageStorage.utils.php');
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -7,6 +7,7 @@ call_user_func(function () {
     $includePath = $_EnginePath . 'modules/flights/';
 
     include($includePath . './utils/calculations/calculatePillageFactor.utils.php');
+    include($includePath . './utils/calculations/calculatePillageStorage.utils.php');
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');
     include($includePath . './utils/fleetCache/updateUserStats.utils.php');

--- a/modules/flights/utils/calculations/calculatePillageStorage.utils.UETest.php
+++ b/modules/flights/utils/calculations/calculatePillageStorage.utils.UETest.php
@@ -1,0 +1,223 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+$_EnginePath = './';
+
+define('INSIDE', true);
+require_once $_EnginePath . 'common/_includes.php';
+require_once $_EnginePath . 'includes/vars.php';
+require_once $_EnginePath . 'includes/helpers/_includes.php';
+require_once $_EnginePath . 'modules/flights/_includes.php';
+
+use UniEngine\Engine\Modules\Flights\Utils\Calculations;
+
+
+/**
+ * @group UniEngineTest
+ */
+class CalculatePillageStorageTestCase extends TestCase {
+    /**
+     * @test
+     */
+    public function itShouldHandleEmptyShipsArray() {
+        $params = [
+            'fleetRow' => [
+                'fleet_id' => '42',
+                'fleet_resource_metal' => '0',
+                'fleet_resource_crystal' => '0',
+                'fleet_resource_deuterium' => '0',
+                'fleet_array' => '',
+            ],
+            'ships' => [],
+        ];
+
+        $result = Calculations\calculatePillageStorage($params);
+
+        $this->assertEquals(
+            0,
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldHandleRegularShipsArray() {
+        $params = [
+            'fleetRow' => [
+                'fleet_id' => '42',
+                'fleet_resource_metal' => '0',
+                'fleet_resource_crystal' => '0',
+                'fleet_resource_deuterium' => '0',
+                'fleet_array' => '202,100;204,100',
+            ],
+            'ships' => [
+                '202' => 100,
+                '204' => 120,
+            ],
+        ];
+
+        $result = Calculations\calculatePillageStorage($params);
+
+        $this->assertEquals(
+            (
+                (5000 * 100) +
+                (50 * 120)
+            ),
+            $result
+        );
+    }
+
+    /**
+     * @test
+     * @backupGlobals enabled
+     */
+    public function itShouldHandleShipsWithForbiddenPillageArray() {
+        global $_Vars_Prices;
+
+        $_Vars_Prices[204]['cantPillage'] = true;
+
+        $params = [
+            'fleetRow' => [
+                'fleet_id' => '42',
+                'fleet_resource_metal' => '0',
+                'fleet_resource_crystal' => '0',
+                'fleet_resource_deuterium' => '0',
+                'fleet_array' => '202,100;204,100',
+            ],
+            'ships' => [
+                '202' => 100,
+                '204' => 120,
+            ],
+        ];
+
+        $result = Calculations\calculatePillageStorage($params);
+
+        $this->assertEquals(
+            (
+                (5000 * 100) +
+                (0 * 120)
+            ),
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldHandleFleetsWithOccupiedSpace() {
+        $params = [
+            'fleetRow' => [
+                'fleet_id' => '42',
+                'fleet_resource_metal' => '1000',
+                'fleet_resource_crystal' => '70',
+                'fleet_resource_deuterium' => '0',
+                'fleet_array' => '202,100;204,100',
+            ],
+            'ships' => [
+                '202' => 100,
+                '204' => 120,
+            ],
+        ];
+
+        $result = Calculations\calculatePillageStorage($params);
+
+        $this->assertEquals(
+            (
+                (5000 * 100) +
+                (50 * 120) -
+                (1000 + 70 + 0)
+            ),
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotBlowUpWhenFleetRowDoesNotHaveAllResourceKeys() {
+        $params = [
+            'fleetRow' => [
+                'fleet_id' => '42',
+                'fleet_resource_metal' => '1000',
+                'fleet_resource_deuterium' => '5',
+                'fleet_array' => '202,100;204,100',
+            ],
+            'ships' => [
+                '202' => 100,
+                '204' => 120,
+            ],
+        ];
+
+        $result = Calculations\calculatePillageStorage($params);
+
+        $this->assertEquals(
+            (
+                (5000 * 100) +
+                (50 * 120) -
+                (1000 + 0 + 5)
+            ),
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotBlowUpWhenFleetRowHasUnknownResource() {
+        $params = [
+            'fleetRow' => [
+                'fleet_id' => '42',
+                'fleet_resource_metal' => '1000',
+                'fleet_resource_unknown' => '5',
+                'fleet_array' => '202,100;204,100',
+            ],
+            'ships' => [
+                '202' => 100,
+                '204' => 120,
+            ],
+        ];
+
+        $result = Calculations\calculatePillageStorage($params);
+
+        $this->assertEquals(
+            (
+                (5000 * 100) +
+                (50 * 120) -
+                (1000 + 0 + 0)
+            ),
+            $result
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldNotBlowUpWhenUsingMixedDataTypes() {
+        $params = [
+            'fleetRow' => [
+                'fleet_id' => '42',
+                'fleet_resource_metal' => '1000',
+                'fleet_resource_crystal' => 70,
+                'fleet_resource_deuterium' => '5',
+                'fleet_array' => '202,100;204,100',
+            ],
+            'ships' => [
+                '202' => '100',
+                204 => 120,
+            ],
+        ];
+
+        $result = Calculations\calculatePillageStorage($params);
+
+        $this->assertEquals(
+            (
+                (5000 * 100) +
+                (50 * 120) -
+                (1000 + 70 + 5)
+            ),
+            $result
+        );
+    }
+}

--- a/modules/flights/utils/calculations/calculatePillageStorage.utils.php
+++ b/modules/flights/utils/calculations/calculatePillageStorage.utils.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Calculations;
+
+use UniEngine\Engine\Includes\Helpers\World\Resources;
+
+/**
+ * @param array $params
+ * @param number $params['fleetRow']
+ * @param number $params['ships'] Ships that have survided the combat
+ */
+function calculatePillageStorage($params) {
+    $fleetRow = $params['fleetRow'];
+    $ships = $params['ships'];
+
+    $pillageStorage = 0;
+
+    foreach ($ships as $shipID => $shipCount) {
+        $shipPillageStorage = getShipsPillageStorageCapacity($shipID);
+
+        $pillageStorage += ($shipPillageStorage * $shipCount);
+    }
+
+    $pillagableResourceKeys = Resources\getKnownPillagableResourceKeys();
+
+    foreach ($pillagableResourceKeys as $resourceKey) {
+        $fleetResourcePropKey = "fleet_resource_{$resourceKey}";
+
+        if (!isset($fleetRow[$fleetResourcePropKey])) {
+            continue;
+        }
+
+        $pillageStorage -= $fleetRow[$fleetResourcePropKey];
+    }
+
+    return max($pillageStorage, 0);
+}
+
+?>

--- a/modules/flights/utils/factories/createFleetDevelopmentLogEntries.utils.php
+++ b/modules/flights/utils/factories/createFleetDevelopmentLogEntries.utils.php
@@ -6,12 +6,19 @@ namespace UniEngine\Engine\Modules\Flights\Utils\Factories;
  * @param array $params
  * @param array $params['originalShips'] Ships that have participated in the combat
  * @param array $params['postCombatShips'] Ships that have survived the combat
+ * @param array $params['resourcesPillage']
+ *              (default: `[]`)
  */
 function createFleetDevelopmentLogEntries($params) {
     $originalShips = $params['originalShips'];
     $postCombatShips = (
         isset($params['postCombatShips']) ?
             $params['postCombatShips'] :
+            []
+    );
+    $resourcesPillage = (
+        isset($params['resourcesPillage']) ?
+            $params['resourcesPillage'] :
             []
     );
 
@@ -30,6 +37,29 @@ function createFleetDevelopmentLogEntries($params) {
         }
 
         $entries[] = implode(',', [ $shipID, $shipCountDifference ]);
+    }
+
+    $pillagableResourceKeyMapping = [
+        'metal' => 'M',
+        'crystal' => 'C',
+        'deuterium' => 'D',
+    ];
+
+    foreach ($resourcesPillage as $resourceKey => $pillagedAmount) {
+        if ($pillagedAmount <= 0) {
+            continue;
+        }
+        if (!isset($pillagableResourceKeyMapping[$resourceKey])) {
+            // No mapping available yet,
+            // probably because of a custom resource added to the game
+            continue;
+        }
+
+        $newEntryParams = [
+            $pillagableResourceKeyMapping[$resourceKey],
+            $pillagedAmount,
+        ];
+        $entries[] = implode(',', $newEntryParams);
     }
 
     return $entries;

--- a/modules/flights/utils/factories/createFleetDevelopmentLogEntries.utils.php
+++ b/modules/flights/utils/factories/createFleetDevelopmentLogEntries.utils.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Factories;
+
+/**
+ * @param array $params
+ * @param array $params['originalShips'] Ships that have participated in the combat
+ * @param array $params['postCombatShips'] Ships that have survived the combat
+ */
+function createFleetDevelopmentLogEntries($params) {
+    $originalShips = $params['originalShips'];
+    $postCombatShips = (
+        isset($params['postCombatShips']) ?
+            $params['postCombatShips'] :
+            []
+    );
+
+    $entries = [];
+
+    foreach ($originalShips as $shipID => $shipOriginalCount) {
+        $shipPostCombatCount = (
+            isset($postCombatShips[$shipID]) ?
+                $postCombatShips[$shipID] :
+                0
+        );
+        $shipCountDifference = ($shipOriginalCount - $shipPostCombatCount);
+
+        if ($shipCountDifference <= 0) {
+            continue;
+        }
+
+        $entries[] = implode(',', [ $shipID, $shipCountDifference ]);
+    }
+
+    return $entries;
+}
+
+?>

--- a/modules/flights/utils/factories/createFleetUpdateEntry.utils.php
+++ b/modules/flights/utils/factories/createFleetUpdateEntry.utils.php
@@ -7,9 +7,13 @@ use UniEngine\Engine\Includes\Helpers\World\Resources;
 /**
  * @param array $params
  * @param string $params['fleetID']
- * @param string $params['state'] (default: null)
- * @param array $params['originalShips'] Ships that have participated in the combat
- * @param array $params['postCombatShips'] Ships that have survived the combat
+ * @param string $params['state']
+ *               (default: `null`)
+ * @param array $params['originalShips']
+ *              Ships that have participated in the combat
+ * @param array $params['postCombatShips']
+ *              (default: `[]`)
+ *              Ships that have survived the combat
  * @param array $params['resourcesPillage']
  *              (default: `Record<PillagableResourceKey, 0>`)
  */
@@ -20,7 +24,11 @@ function createFleetUpdateEntry($params) {
             null
     );
     $originalShips = $params['originalShips'];
-    $postCombatShips = $params['postCombatShips'];
+    $postCombatShips = (
+        isset($params['postCombatShips']) ?
+            $params['postCombatShips'] :
+            []
+    );
 
     $updateEntry = [
         'fleet_id' => $params['fleetID'],

--- a/modules/flights/utils/factories/createFleetUpdateEntry.utils.php
+++ b/modules/flights/utils/factories/createFleetUpdateEntry.utils.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Factories;
+
+use UniEngine\Engine\Includes\Helpers\World\Resources;
+
+/**
+ * @param array $params
+ * @param string $params['fleetID']
+ * @param string $params['state'] (default: null)
+ * @param array $params['originalShips'] Ships that have participated in the combat
+ * @param array $params['postCombatShips'] Ships that have survived the combat
+ * @param array $params['resourcesPillage']
+ *              (default: `Record<PillagableResourceKey, 0>`)
+ */
+function createFleetUpdateEntry($params) {
+    $state = (
+        isset($params['state']) ?
+            $params['state'] :
+            null
+    );
+    $originalShips = $params['originalShips'];
+    $postCombatShips = $params['postCombatShips'];
+
+    $updateEntry = [
+        'fleet_id' => $params['fleetID'],
+        'fleet_mess' => $state,
+        'fleet_amount' => 0,
+        'fleet_array' => [],
+        'fleet_array_lost' => [],
+        // fleet_resource_*
+    ];
+
+    $pillagableResourceKeys = Resources\getKnownPillagableResourceKeys();
+
+    foreach ($pillagableResourceKeys as $resourceKey) {
+        $entryKey = "fleet_resource_{$resourceKey}";
+
+        $updateEntry[$entryKey] = (
+            isset($params['resourcesPillage'][$resourceKey]) ?
+                $params['resourcesPillage'][$resourceKey] :
+                0
+        );
+    }
+
+    foreach ($postCombatShips as $shipID => $shipCount) {
+        if ($shipCount <= 0) {
+            continue;
+        }
+
+        $updateEntry['fleet_amount'] += $shipCount;
+        $updateEntry['fleet_array'][$shipID] = $shipCount;
+    }
+    foreach ($originalShips as $shipID => $shipOriginalCount) {
+        $shipPostCombatCount = (
+            isset($postCombatShips[$shipID]) ?
+                $postCombatShips[$shipID] :
+                0
+        );
+        $shipLostCount = ($shipOriginalCount - $shipPostCombatCount);
+
+        if ($shipLostCount <= 0) {
+            continue;
+        }
+
+        $updateEntry['fleet_array_lost'][$shipID] = $shipLostCount;
+    }
+
+    return $updateEntry;
+}
+
+?>

--- a/modules/flights/utils/factories/index.php
+++ b/modules/flights/utils/factories/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>


### PR DESCRIPTION
## Summary:

Certain actions like pillage storage capacity calculation, fleet row updates aggregation & development log updates aggregation are all common to all three types of attacks (Solo, United, Destruction), however they all have these actions duplicated in the code. These things should all be shared, one way or the other.

## Changelog:

- [x] Export pillage storage capacity calculation into a separate function
    - [x] Function export (as utility)
    - [x] Use in Regular attack
    - [x] Use in Group attack (ACS)
    - [x] Use in Moon destruction
- [x] Export fleet update entries aggregation into a separate util function
    - [x] Function export (as utility)
    - [x] Use in Regular attack
    - [x] Use in Group attack (ACS)
    - [x] Use in Moon destruction
- [x] Export fleet change devlog entries aggregation into a separate util function
    - [x] Function export (as utility)
    - [x] Update the utility to handle pillages resources as well
    - [x] Use in Regular attack
    - [x] Use in Group attack (ACS)
    - [x] Use in Moon destruction

## Related issues or PRs:

- #91 
