### PR TITLE
Refactor fleet missions' code | Part 07 | Post-combat system messages

### DIFF
--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -818,7 +818,6 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                 {
                     $UserStatsData[$UserID]['raids_lost'] += 1;
                 }
-                $ReportColor = 'green';
                 $ReportColor2 = 'red';
             }
             elseif($Result === COMBAT_DRAW)
@@ -831,7 +830,6 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                 {
                     $UserStatsData[$UserID]['raids_draw'] += 1;
                 }
-                $ReportColor = 'orange';
                 $ReportColor2 = 'orange';
             }
             elseif($Result === COMBAT_DEF)
@@ -844,7 +842,6 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                 {
                     $UserStatsData[$UserID]['raids_won'] += 1;
                 }
-                $ReportColor = 'red';
                 $ReportColor2 = 'green';
             }
 
@@ -921,34 +918,31 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
             }
             if($Result === COMBAT_ATK)
             {
-                $ReportColor = 'green';
                 $ReportColor2 = 'red';
             }
             elseif($Result === COMBAT_DRAW)
             {
-                $ReportColor = 'orange';
                 $ReportColor2 = 'orange';
             }
             elseif($Result === COMBAT_DEF)
             {
-                $ReportColor = 'red';
                 $ReportColor2 = 'green';
             }
         }
 
+        $messageJSON = Flights\Utils\Factories\createCombatResultForAttackersMessage([
+            'missionType' => 1,
+            'report' => $CreatedReport,
+            'combatResult' => $Result,
+            'totalAttackersResourcesLoss' => $attackersResourceLosses,
+            'totalDefendersResourcesLoss' => $defendersResourceLosses,
+            'totalResourcesPillage' => $resourcesPillage,
+            'fleetRow' => $FleetRow,
+        ]);
+
+        Cache_Message($CurrentUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $messageJSON);
+
         $TargetTypeMsg = $_Lang['BR_Target_'.$FleetRow['fleet_end_type']];
-        $Message['msg_id'] = '071';
-        $Message['args'] = array
-        (
-            $ReportID, $ReportColor, $FleetRow['fleet_end_galaxy'], $FleetRow['fleet_end_system'], $FleetRow['fleet_end_planet'], $TargetTypeMsg,
-            prettyNumber($RealDebrisMetalAtk + $RealDebrisCrystalAtk + $RealDebrisDeuteriumAtk),
-            prettyNumber($RealDebrisCrystalDef + $RealDebrisMetalDef + $RealDebrisDeuteriumDef),
-            prettyNumber($StolenMet), prettyNumber($StolenCry), prettyNumber($StolenDeu),
-            prettyNumber($TotalLostMetal), prettyNumber($TotalLostCrystal),
-            $ReportHasHLinkRelative, $ReportHasHLinkReal
-        );
-        $Message = json_encode($Message);
-        Cache_Message($CurrentUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $Message);
 
         if(!$IsAbandoned)
         {

--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -345,6 +345,8 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
         ]);
 
         // Parse result data - Defenders
+        $rebuiltDefenseSystems = [];
+
         $i = 1;
         if(!empty($DefendingFleets))
         {
@@ -366,8 +368,8 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                             {
                                 $Fluctuation = 0;
                             }
-                            $Rebuilt[$ID] = round($DefSysLost[$ID] * (($Chance + $Fluctuation) / 100));
-                            $Count += $Rebuilt[$ID];
+                            $rebuiltDefenseSystems[$ID] = round($DefSysLost[$ID] * (($Chance + $Fluctuation) / 100));
+                            $Count += $rebuiltDefenseSystems[$ID];
                             if($DefendingFleets[0][$ID] < $Count)
                             {
                                 $Count = $DefendingFleets[0][$ID];
@@ -793,8 +795,6 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
 
         $CreatedReport = CreateBattleReport($ReportData, array('atk' => $AttackersIDs, 'def' => $DefendersIDs), $DisallowAttackers);
         $ReportID = $CreatedReport['ID'];
-        $ReportHasHLinkRelative = 'battlereport.php?hash='.$CreatedReport['Hash'];
-        $ReportHasHLinkReal = GAMEURL.$ReportHasHLinkRelative;
 
         $Return['FleetArchive'][$FleetRow['fleet_id']]['Fleet_ReportID'] = $ReportID;
         if(!empty($DefendingFleetID))
@@ -818,7 +818,6 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                 {
                     $UserStatsData[$UserID]['raids_lost'] += 1;
                 }
-                $ReportColor2 = 'red';
             }
             elseif($Result === COMBAT_DRAW)
             {
@@ -830,7 +829,6 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                 {
                     $UserStatsData[$UserID]['raids_draw'] += 1;
                 }
-                $ReportColor2 = 'orange';
             }
             elseif($Result === COMBAT_DEF)
             {
@@ -842,7 +840,6 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                 {
                     $UserStatsData[$UserID]['raids_won'] += 1;
                 }
-                $ReportColor2 = 'green';
             }
 
             // Update User Destroyed & Lost Stats
@@ -916,18 +913,6 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
             {
                 $UserStatsData[$UserID]['raids_inAlly'] += 1;
             }
-            if($Result === COMBAT_ATK)
-            {
-                $ReportColor2 = 'red';
-            }
-            elseif($Result === COMBAT_DRAW)
-            {
-                $ReportColor2 = 'orange';
-            }
-            elseif($Result === COMBAT_DEF)
-            {
-                $ReportColor2 = 'green';
-            }
         }
 
         $messageJSON = Flights\Utils\Factories\createCombatResultForAttackersMessage([
@@ -942,34 +927,19 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
 
         Cache_Message($CurrentUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $messageJSON);
 
-        $TargetTypeMsg = $_Lang['BR_Target_'.$FleetRow['fleet_end_type']];
+        if (!$IsAbandoned) {
+            $messageJSON = Flights\Utils\Factories\createCombatResultForMainDefenderMessage([
+                'report' => $CreatedReport,
+                'combatResult' => $Result,
+                'fleetRow' => $FleetRow,
+                'rebuiltElements' => $rebuiltDefenseSystems,
+                'hasLostAnyDefenseSystems' => Flights\Utils\Helpers\hasLostAnyDefenseSystem([
+                    'originalShips' => $DefendingFleets,
+                    'postCombatShips' => $DefShips,
+                ]),
+            ]);
 
-        if(!$IsAbandoned)
-        {
-            $Message = false;
-            $Message['msg_id'] = '074';
-            if(!empty($Rebuilt) AND (array)$Rebuilt === $Rebuilt)
-            {
-                foreach($Rebuilt as $SysID => $Count)
-                {
-                    $RebuildReport[] = '<b>'.$_Lang['tech'][$SysID].'</b> - '.$Count;
-                }
-                $RebuildReport = implode('<br/>', $RebuildReport);
-            }
-            else
-            {
-                if(!isset($DefSysLostIDs) || count($DefSysLostIDs) == 1)
-                {
-                    $RebuildReport = $_Lang['no_loses_in_defence'];
-                }
-                else
-                {
-                    $RebuildReport = $_Lang['nothing_have_been_rebuilt'];
-                }
-            }
-            $Message['args'] = array($ReportID, $ReportColor2, $FleetRow['fleet_end_galaxy'], $FleetRow['fleet_end_system'], $FleetRow['fleet_end_planet'], $TargetTypeMsg, $RebuildReport, $ReportHasHLinkRelative, $ReportHasHLinkReal);
-            $Message = json_encode($Message);
-            Cache_Message($TargetUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $Message);
+            Cache_Message($TargetUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $messageJSON);
         }
 
         if (count($DefendersIDs) > 1) {

--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -978,14 +978,16 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
             Cache_Message($TargetUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $Message);
         }
 
-        if(count($DefendersIDs) > 1)
-        {
-            $Message = false;
-            $Message['msg_id'] = '075';
-            $Message['args'] = array($ReportID, $ReportColor2, $FleetRow['fleet_end_galaxy'], $FleetRow['fleet_end_system'], $FleetRow['fleet_end_planet'], $TargetTypeMsg, $ReportHasHLinkRelative, $ReportHasHLinkReal);
-            $Message = json_encode($Message);
+        if (count($DefendersIDs) > 1) {
+            $messageJSON = Flights\Utils\Factories\createCombatResultForAlliedDefendersMessage([
+                'report' => $CreatedReport,
+                'combatResult' => $Result,
+                'fleetRow' => $FleetRow,
+            ]);
+
             unset($DefendersIDs[0]);
-            Cache_Message($DefendersIDs, 0, $FleetRow['fleet_start_time'], 3, '003', '017', $Message);
+
+            Cache_Message($DefendersIDs, 0, $FleetRow['fleet_start_time'], 3, '003', '017', $messageJSON);
         }
 
         if(!empty($TriggerTasksCheck))

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -1211,18 +1211,17 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
             Cache_Message($TargetUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $Message);
         }
 
-        if(count($DefendersIDs) > 1)
-        {
-            $Message = false;
-            $Message['msg_id'] = '075';
-            $Message['args'] = array
-            (
-                $ReportID, $ReportColor2, $FleetRow['fleet_end_galaxy'], $FleetRow['fleet_end_system'], $FleetRow['fleet_end_planet'],
-                $TargetTypeMsg, $ReportHasHLinkRelative, $ReportHasHLinkReal
-            );
-            $Message = json_encode($Message);
+        if (count($DefendersIDs) > 1) {
+            $messageJSON = Flights\Utils\Factories\createCombatResultForAlliedDefendersMessage([
+                'report' => $CreatedReport,
+                'combatResult' => $Result,
+                'fleetRow' => $FleetRow,
+                'hasMoonBeenDestroyed' => $MoonHasBeenDestroyed,
+            ]);
+
             unset($DefendersIDs[0]);
-            Cache_Message($DefendersIDs, 0, $FleetRow['fleet_start_time'], 3, '003', '017', $Message);
+
+            Cache_Message($DefendersIDs, 0, $FleetRow['fleet_start_time'], 3, '003', '017', $messageJSON);
         }
 
         if(!empty($TriggerTasksCheck))

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -995,14 +995,7 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                 {
                     $UserStatsData[$UserID]['raids_lost'] += 1;
                 }
-                if($FleetDestroyedByMoon)
-                {
-                    $ReportColor = '#AD5CD6';
-                }
-                else
-                {
-                    $ReportColor = 'green';
-                }
+
                 if($MoonHasBeenDestroyed === 1)
                 {
                     $ReportColor3 = 'green';
@@ -1023,7 +1016,6 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                 {
                     $UserStatsData[$UserID]['raids_draw'] += 1;
                 }
-                $ReportColor = 'orange';
                 $ReportColor2 = 'orange';
             }
             elseif($Result === COMBAT_DEF)
@@ -1036,7 +1028,6 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                 {
                     $UserStatsData[$UserID]['raids_won'] += 1;
                 }
-                $ReportColor = 'red';
                 $ReportColor2 = 'green';
             }
 
@@ -1122,14 +1113,6 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
             }
             if($Result === COMBAT_ATK)
             {
-                if($FleetDestroyedByMoon)
-                {
-                    $ReportColor = '#AD5CD6';
-                }
-                else
-                {
-                    $ReportColor = 'green';
-                }
                 if($MoonHasBeenDestroyed === 1)
                 {
                     $ReportColor3 = 'green';
@@ -1142,35 +1125,37 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
             }
             elseif($Result === COMBAT_DRAW)
             {
-                $ReportColor = 'orange';
                 $ReportColor2 = 'orange';
             }
             elseif($Result === COMBAT_DEF)
             {
-                $ReportColor = 'red';
                 $ReportColor2 = 'green';
             }
         }
+
+        $messageJSON = Flights\Utils\Factories\createCombatResultForAttackersMessage([
+            'missionType' => 9,
+            'report' => $CreatedReport,
+            'combatResult' => $Result,
+            'totalAttackersResourcesLoss' => $attackersResourceLosses,
+            'totalDefendersResourcesLoss' => $defendersResourceLosses,
+            'totalResourcesPillage' => (
+                !$FleetHasBeenDestroyed ?
+                $resourcesPillage :
+                null
+            ),
+            'fleetRow' => $FleetRow,
+            'hasMoonBeenDestroyed' => $MoonHasBeenDestroyed,
+            'hasFleetBeenDestroyedByMoon' => $FleetDestroyedByMoon,
+        ]);
+
+        Cache_Message($CurrentUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $messageJSON);
 
         $TargetTypeMsg = $_Lang['BR_Target_'.$FleetRow['fleet_end_type']];
         if(!empty($ReportColor3))
         {
             $TargetTypeMsg = "<span style=\"color: {$ReportColor3}\">{$TargetTypeMsg}</span>";
         }
-        $Message['msg_id'] = '072';
-        $Message['args'] = array
-        (
-            $ReportID, $ReportColor, $FleetRow['fleet_end_galaxy'], $FleetRow['fleet_end_system'], $FleetRow['fleet_end_planet'], $TargetTypeMsg,
-            prettyNumber($RealDebrisMetalAtk + $RealDebrisCrystalAtk + $RealDebrisDeuteriumAtk),
-            prettyNumber($RealDebrisCrystalDef + $RealDebrisMetalDef + $RealDebrisDeuteriumDef),
-            ($FleetDestroyedByMoon != true ? prettyNumber($StolenMet) : 0),
-            ($FleetDestroyedByMoon != true ? prettyNumber($StolenCry) : 0),
-            ($FleetDestroyedByMoon != true ? prettyNumber($StolenDeu) : 0),
-            prettyNumber($TotalLostMetal), prettyNumber($TotalLostCrystal),
-            $ReportHasHLinkRelative, $ReportHasHLinkReal
-        );
-        $Message = json_encode($Message);
-        Cache_Message($CurrentUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $Message);
 
         if(!$IsAbandoned)
         {

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -524,6 +524,8 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
             ]);
         }
 
+        $rebuiltDefenseSystems = [];
+
         // Parse result data - Defenders
         if(!empty($DefendingFleets))
         {
@@ -545,8 +547,8 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                             {
                                 $Fluctuation = 0;
                             }
-                            $Rebuilt[$ID] = round($DefSysLost[$ID] * (($Chance + $Fluctuation) / 100));
-                            $Count += $Rebuilt[$ID];
+                            $rebuiltDefenseSystems[$ID] = round($DefSysLost[$ID] * (($Chance + $Fluctuation) / 100));
+                            $Count += $rebuiltDefenseSystems[$ID];
                             if($DefendingFleets[0][$ID] < $Count)
                             {
                                 $Count = $DefendingFleets[0][$ID];
@@ -1086,8 +1088,6 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
 
         $CreatedReport = CreateBattleReport($ReportData, array('atk' => $AttackersIDs, 'def' => $DefendersIDs), $DisallowAttackers);
         $ReportID = $CreatedReport['ID'];
-        $ReportHasHLinkRelative = 'battlereport.php?hash='.$CreatedReport['Hash'];
-        $ReportHasHLinkReal = GAMEURL.$ReportHasHLinkRelative;
 
         foreach($AttackingFleetID as $FleetID)
         {
@@ -1154,7 +1154,6 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 {
                     $UserStatsData[$UserID]['raids_lost'] += 1;
                 }
-                $ReportColor2 = 'red';
             }
             else if($Result === COMBAT_DRAW)
             {
@@ -1173,7 +1172,6 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 {
                     $UserStatsData[$UserID]['raids_draw'] += 1;
                 }
-                $ReportColor2 = 'orange';
             }
             else if($Result === COMBAT_DEF)
             {
@@ -1183,7 +1181,6 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 foreach($DefendersIDs as $UserID){
                     $UserStatsData[$UserID]['raids_won'] += 1;
                 }
-                $ReportColor2 = 'green';
             }
 
             // Update User Destroyed & Lost Stats
@@ -1275,18 +1272,6 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
             {
                 $UserStatsData[$UserID]['raids_inAlly'] += 1;
             }
-            if($Result === COMBAT_ATK)
-            {
-                $ReportColor2 = 'red';
-            }
-            else if($Result === COMBAT_DRAW)
-            {
-                $ReportColor2 = 'orange';
-            }
-            else if($Result === COMBAT_DEF)
-            {
-                $ReportColor2 = 'green';
-            }
         }
 
         if($MoonHasBeenCreated AND $TargetUser['ally_id'] > 0)
@@ -1300,34 +1285,19 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
             }
         }
 
-        $TargetTypeMsg = $_Lang['BR_Target_'.$FleetRow['fleet_end_type']];
+        if (!$IsAbandoned) {
+            $messageJSON = Flights\Utils\Factories\createCombatResultForMainDefenderMessage([
+                'report' => $CreatedReport,
+                'combatResult' => $Result,
+                'fleetRow' => $FleetRow,
+                'rebuiltElements' => $rebuiltDefenseSystems,
+                'hasLostAnyDefenseSystems' => Flights\Utils\Helpers\hasLostAnyDefenseSystem([
+                    'originalShips' => $DefendingFleets,
+                    'postCombatShips' => $DefShips,
+                ]),
+            ]);
 
-        if(!$IsAbandoned)
-        {
-            $Message = false;
-            $Message['msg_id'] = '074';
-            if(!empty($Rebuilt) AND (array)$Rebuilt === $Rebuilt)
-            {
-                foreach($Rebuilt as $SysID => $Count)
-                {
-                    $RebuildReport[] = '<b>'.$_Lang['tech'][$SysID].'</b> - '.$Count;
-                }
-                $RebuildReport = implode('<br/>', $RebuildReport);
-            }
-            else
-            {
-                if(!isset($DefSysLostIDs) || count($DefSysLostIDs) == 1)
-                {
-                    $RebuildReport = $_Lang['no_loses_in_defence'];
-                }
-                else
-                {
-                    $RebuildReport = $_Lang['nothing_have_been_rebuilt'];
-                }
-            }
-            $Message['args'] = array($ReportID, $ReportColor2, $FleetRow['fleet_end_galaxy'], $FleetRow['fleet_end_system'], $FleetRow['fleet_end_planet'], $TargetTypeMsg, $RebuildReport, $ReportHasHLinkRelative, $ReportHasHLinkReal);
-            $Message = json_encode($Message);
-            Cache_Message($TargetUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $Message);
+            Cache_Message($TargetUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $messageJSON);
         }
 
         if (count($DefendersIDs) > 1) {

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -1336,14 +1336,16 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
             Cache_Message($TargetUserID, 0, $FleetRow['fleet_start_time'], 3, '003', '012', $Message);
         }
 
-        if(count($DefendersIDs) > 1)
-        {
-            $Message = false;
-            $Message['msg_id'] = '075';
-            $Message['args'] = array($ReportID, $ReportColor2, $FleetRow['fleet_end_galaxy'], $FleetRow['fleet_end_system'], $FleetRow['fleet_end_planet'], $TargetTypeMsg, $ReportHasHLinkRelative, $ReportHasHLinkReal);
-            $Message = json_encode($Message);
+        if (count($DefendersIDs) > 1) {
+            $messageJSON = Flights\Utils\Factories\createCombatResultForAlliedDefendersMessage([
+                'report' => $CreatedReport,
+                'combatResult' => $Result,
+                'fleetRow' => $FleetRow,
+            ]);
+
             unset($DefendersIDs[0]);
-            Cache_Message($DefendersIDs, 0, $FleetRow['fleet_start_time'], 3, '003', '017', $Message);
+
+            Cache_Message($DefendersIDs, 0, $FleetRow['fleet_start_time'], 3, '003', '017', $messageJSON);
         }
 
         $Message = false;

--- a/includes/helpers/common/collections.functions.php
+++ b/includes/helpers/common/collections.functions.php
@@ -40,4 +40,16 @@ function without($collection, $excludedElement) {
     });
 }
 
+function mapEntries($collection, $iteratee) {
+    $mappedObject = [];
+
+    foreach ($collection as $key => $value) {
+        $entry = $iteratee($value, $key);
+
+        $mappedObject[$entry[0]] = $entry[1];
+    }
+
+    return $mappedObject;
+}
+
 ?>

--- a/includes/helpers/common/navigation.functions.php
+++ b/includes/helpers/common/navigation.functions.php
@@ -8,6 +8,13 @@ function getPageURL($pageType, $pageParams) {
             return "login.php";
         case "registration":
             return "reg_mainpage.php";
+        case "battleReportByHash":
+            return buildHref([
+                'path' => 'battlereport.php',
+                'query' => [
+                    'hash' => $pageParams['hash'],
+                ],
+            ]);
         default:
             throw new \Exception("UniEngine::getPageURL(): cannot navigate to '{$pageType}'");
     }

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -14,6 +14,7 @@ call_user_func(function () {
     include($includePath . './utils/factories/createFleetUpdateEntry.utils.php');
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');
     include($includePath . './utils/fleetCache/updateUserStats.utils.php');
+    include($includePath . './utils/helpers/hasLostAnyDefenseSystem.utils.php');
     include($includePath . './utils/initializers/technologies.utils.php');
     include($includePath . './utils/initializers/userStats.utils.php');
     include($includePath . './utils/modifiers/calculateMoraleModifiers.utils.php');

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -9,6 +9,7 @@ call_user_func(function () {
     include($includePath . './utils/calculations/calculatePillageFactor.utils.php');
     include($includePath . './utils/calculations/calculatePillageStorage.utils.php');
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
+    include($includePath . './utils/factories/createCombatMessages.utils.php');
     include($includePath . './utils/factories/createFleetDevelopmentLogEntries.utils.php');
     include($includePath . './utils/factories/createFleetUpdateEntry.utils.php');
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');

--- a/modules/flights/utils/factories/createCombatMessages.utils.php
+++ b/modules/flights/utils/factories/createCombatMessages.utils.php
@@ -2,40 +2,46 @@
 
 namespace UniEngine\Engine\Modules\Flights\Utils\Factories;
 
+use UniEngine\Engine\Includes\Helpers\Common\Navigation;
+
 /**
  * @param array $params
- * @param string $params['reportID']
+ * @param string $params['report']
  * @param string $params['combatResult']
  * @param string $params['fleetRow']
  */
 function createCombatResultForAlliedDefendersMessage($params) {
     global $_Lang;
 
+    $report = $params['report'];
     $combatResult = $params['combatResult'];
     $fleetRow = $params['fleetRow'];
+
+    $reportHashlinkRelative = Navigation\getPageURL(
+        'battleReportByHash',
+        [ 'hash' => $report['Hash'] ]
+    );
+    $reportHashlinkAbsolute = GAMEURL . $reportHashlinkRelative;
 
     $message = [
         'msg_id' => '075',
         'args' => [
-            $params['reportID'],
-            (
-                $combatResult === COMBAT_ATK ?
-                    'red' :
-                    (
-                        $combatResult === COMBAT_DRAW ?
-                        'orange' :
-                        'green'
-                    )
-            ),
+            $report['ID'],
+            classNames([
+                'red' => ($combatResult === COMBAT_ATK),
+                'orange' => ($combatResult === COMBAT_DRAW),
+                'green' => ($combatResult === COMBAT_DEF),
+            ]),
             $fleetRow['fleet_end_galaxy'],
             $fleetRow['fleet_end_system'],
             $fleetRow['fleet_end_planet'],
             $_Lang['BR_Target_'.$fleetRow['fleet_end_type']],
-
+            $reportHashlinkRelative,
+            $reportHashlinkAbsolute
         ],
     ];
 
-    return $message;
+    return json_encode($message);
 }
 
 ?>

--- a/modules/flights/utils/factories/createCombatMessages.utils.php
+++ b/modules/flights/utils/factories/createCombatMessages.utils.php
@@ -9,6 +9,7 @@ use UniEngine\Engine\Includes\Helpers\Common\Navigation;
  * @param string $params['report']
  * @param string $params['combatResult']
  * @param string $params['fleetRow']
+ * @param string $params['hasMoonBeenDestroyed'] (default: null)
  */
 function createCombatResultForAlliedDefendersMessage($params) {
     global $_Lang;
@@ -16,6 +17,36 @@ function createCombatResultForAlliedDefendersMessage($params) {
     $report = $params['report'];
     $combatResult = $params['combatResult'];
     $fleetRow = $params['fleetRow'];
+    $hasMoonBeenDestroyed = (
+        isset($params['hasMoonBeenDestroyed']) ?
+            $params['hasMoonBeenDestroyed'] :
+            null
+    );
+
+    $hasMoonDestructionAttempt = (
+        $combatResult === COMBAT_ATK &&
+        $hasMoonBeenDestroyed !== null
+    );
+
+    $targetTypeLabelContent = $_Lang['BR_Target_'.$fleetRow['fleet_end_type']];
+
+    $targetTypeLabel = (
+        $hasMoonDestructionAttempt ?
+        buildDOMElementHTML([
+            'tagName' => 'span',
+            'attrs' => [
+                'style' => (
+                    "color: " .
+                    classNames([
+                        'green' => ($hasMoonBeenDestroyed === 1),
+                        'orange' => ($hasMoonBeenDestroyed !== 1),
+                    ])
+                )
+            ],
+            'contentHTML' => $targetTypeLabelContent,
+        ]) :
+        $targetTypeLabelContent
+    );
 
     $reportHashlinkRelative = Navigation\getPageURL(
         'battleReportByHash',
@@ -35,7 +66,7 @@ function createCombatResultForAlliedDefendersMessage($params) {
             $fleetRow['fleet_end_galaxy'],
             $fleetRow['fleet_end_system'],
             $fleetRow['fleet_end_planet'],
-            $_Lang['BR_Target_'.$fleetRow['fleet_end_type']],
+            $targetTypeLabel,
             $reportHashlinkRelative,
             $reportHashlinkAbsolute
         ],

--- a/modules/flights/utils/factories/createCombatMessages.utils.php
+++ b/modules/flights/utils/factories/createCombatMessages.utils.php
@@ -4,6 +4,7 @@ namespace UniEngine\Engine\Modules\Flights\Utils\Factories;
 
 use UniEngine\Engine\Includes\Helpers\Common\Navigation;
 use UniEngine\Engine\Includes\Helpers\World\Resources;
+use UniEngine\Engine\Includes\Helpers\Common\Collections;
 
 /**
  * @param array $params
@@ -26,8 +27,13 @@ function createCombatResultForAttackersMessage($params) {
     $totalDefendersResourcesLoss = $params['totalDefendersResourcesLoss'];
     $totalResourcesPillage = (
         isset($params['totalResourcesPillage']) ?
-        $params['totalResourcesPillage'] :
-        null
+            $params['totalResourcesPillage'] :
+            Collections\mapEntries(
+                Resources\getKnownPillagableResourceKeys(),
+                function ($resourceKey) {
+                    return [ $resourceKey, 0 ];
+                }
+            )
     );
     $fleetRow = $params['fleetRow'];
     $hasMoonBeenDestroyed = (
@@ -40,15 +46,6 @@ function createCombatResultForAttackersMessage($params) {
             $params['hasFleetBeenDestroyedByMoon'] :
             null
     );
-
-    if ($totalResourcesPillage === null) {
-        $totalResourcesPillage = [];
-        $pillagableResourceKeys = Resources\getKnownPillagableResourceKeys();
-
-        foreach ($pillagableResourceKeys as $resourceKey) {
-            $totalResourcesPillage[$resourceKey] = 0;
-        }
-    }
 
     $hasMoonDestructionAttempt = (
         $combatResult === COMBAT_ATK &&

--- a/modules/flights/utils/factories/createCombatMessages.utils.php
+++ b/modules/flights/utils/factories/createCombatMessages.utils.php
@@ -52,11 +52,7 @@ function createCombatResultForAttackersMessage($params) {
         $hasMoonBeenDestroyed !== null
     );
 
-    $reportHashlinkRelative = Navigation\getPageURL(
-        'battleReportByHash',
-        [ 'hash' => $report['Hash'] ]
-    );
-    $reportHashlinkAbsolute = GAMEURL . $reportHashlinkRelative;
+    $reportHashlink = _createReportHashlink([ 'report' => $report ]);
 
     $message = [
         'msg_id' => (
@@ -93,8 +89,8 @@ function createCombatResultForAttackersMessage($params) {
                 $totalAttackersResourcesLoss['recoverableLoss']['crystal'] +
                 $totalDefendersResourcesLoss['recoverableLoss']['crystal']
             ),
-            $reportHashlinkRelative,
-            $reportHashlinkAbsolute
+            $reportHashlink['relative'],
+            $reportHashlink['absolute']
         ],
     ];
 
@@ -123,11 +119,7 @@ function createCombatResultForAlliedDefendersMessage($params) {
         $hasMoonBeenDestroyed !== null
     );
 
-    $reportHashlinkRelative = Navigation\getPageURL(
-        'battleReportByHash',
-        [ 'hash' => $report['Hash'] ]
-    );
-    $reportHashlinkAbsolute = GAMEURL . $reportHashlinkRelative;
+    $reportHashlink = _createReportHashlink([ 'report' => $report ]);
 
     $message = [
         'msg_id' => '075',
@@ -146,12 +138,28 @@ function createCombatResultForAlliedDefendersMessage($params) {
                 'hasMoonDestructionAttempt' => $hasMoonDestructionAttempt,
                 'fleetRow' => $fleetRow,
             ]),
-            $reportHashlinkRelative,
-            $reportHashlinkAbsolute
+            $reportHashlink['relative'],
+            $reportHashlink['absolute']
         ],
     ];
 
     return json_encode($message);
+}
+
+/**
+ * @param array $params
+ * @param array $params['report']
+ */
+function _createReportHashlink($params) {
+    $reportHashlinkRelative = Navigation\getPageURL(
+        'battleReportByHash',
+        [ 'hash' => $params['report']['Hash'] ]
+    );
+
+    return [
+        'relative' => $reportHashlinkRelative,
+        'absolute' => (GAMEURL . $reportHashlinkRelative),
+    ];
 }
 
 /**

--- a/modules/flights/utils/factories/createCombatMessages.utils.php
+++ b/modules/flights/utils/factories/createCombatMessages.utils.php
@@ -19,8 +19,6 @@ use UniEngine\Engine\Includes\Helpers\World\Resources;
  * @param string $params['hasFleetBeenDestroyedByMoon'] (default: null)
  */
 function createCombatResultForAttackersMessage($params) {
-    global $_Lang;
-
     $missionType = $params['missionType'];
     $report = $params['report'];
     $combatResult = $params['combatResult'];
@@ -57,26 +55,6 @@ function createCombatResultForAttackersMessage($params) {
         $hasMoonBeenDestroyed !== null
     );
 
-    $targetTypeLabelContent = $_Lang['BR_Target_'.$fleetRow['fleet_end_type']];
-
-    $targetTypeLabel = (
-        $hasMoonDestructionAttempt ?
-        buildDOMElementHTML([
-            'tagName' => 'span',
-            'attrs' => [
-                'style' => (
-                    "color: " .
-                    classNames([
-                        'green' => ($hasMoonBeenDestroyed === 1),
-                        'orange' => ($hasMoonBeenDestroyed !== 1),
-                    ])
-                )
-            ],
-            'contentHTML' => $targetTypeLabelContent,
-        ]) :
-        $targetTypeLabelContent
-    );
-
     $reportHashlinkRelative = Navigation\getPageURL(
         'battleReportByHash',
         [ 'hash' => $report['Hash'] ]
@@ -100,7 +78,11 @@ function createCombatResultForAttackersMessage($params) {
             $fleetRow['fleet_end_galaxy'],
             $fleetRow['fleet_end_system'],
             $fleetRow['fleet_end_planet'],
-            $targetTypeLabel,
+            _createTargetTypeLabel([
+                'hasMoonBeenDestroyed' => $hasMoonBeenDestroyed,
+                'hasMoonDestructionAttempt' => $hasMoonDestructionAttempt,
+                'fleetRow' => $fleetRow,
+            ]),
             prettyNumber(array_sum($totalAttackersResourcesLoss['realLoss'])),
             prettyNumber(array_sum($totalDefendersResourcesLoss['realLoss'])),
             prettyNumber($totalResourcesPillage['metal']),
@@ -130,8 +112,6 @@ function createCombatResultForAttackersMessage($params) {
  * @param string $params['hasMoonBeenDestroyed'] (default: null)
  */
 function createCombatResultForAlliedDefendersMessage($params) {
-    global $_Lang;
-
     $report = $params['report'];
     $combatResult = $params['combatResult'];
     $fleetRow = $params['fleetRow'];
@@ -144,26 +124,6 @@ function createCombatResultForAlliedDefendersMessage($params) {
     $hasMoonDestructionAttempt = (
         $combatResult === COMBAT_ATK &&
         $hasMoonBeenDestroyed !== null
-    );
-
-    $targetTypeLabelContent = $_Lang['BR_Target_'.$fleetRow['fleet_end_type']];
-
-    $targetTypeLabel = (
-        $hasMoonDestructionAttempt ?
-        buildDOMElementHTML([
-            'tagName' => 'span',
-            'attrs' => [
-                'style' => (
-                    "color: " .
-                    classNames([
-                        'green' => ($hasMoonBeenDestroyed === 1),
-                        'orange' => ($hasMoonBeenDestroyed !== 1),
-                    ])
-                )
-            ],
-            'contentHTML' => $targetTypeLabelContent,
-        ]) :
-        $targetTypeLabelContent
     );
 
     $reportHashlinkRelative = Navigation\getPageURL(
@@ -184,13 +144,51 @@ function createCombatResultForAlliedDefendersMessage($params) {
             $fleetRow['fleet_end_galaxy'],
             $fleetRow['fleet_end_system'],
             $fleetRow['fleet_end_planet'],
-            $targetTypeLabel,
+            _createTargetTypeLabel([
+                'hasMoonBeenDestroyed' => $hasMoonBeenDestroyed,
+                'hasMoonDestructionAttempt' => $hasMoonDestructionAttempt,
+                'fleetRow' => $fleetRow,
+            ]),
             $reportHashlinkRelative,
             $reportHashlinkAbsolute
         ],
     ];
 
     return json_encode($message);
+}
+
+/**
+ * @param array $params
+ * @param array $params['fleetRow']
+ * @param boolean $params['hasMoonBeenDestroyed']
+ * @param boolean $params['hasMoonDestructionAttempt']
+ */
+function _createTargetTypeLabel($params) {
+    global $_Lang;
+
+    $fleetEndType = $params['fleetRow']['fleet_end_type'];
+    $hasMoonBeenDestroyed = $params['hasMoonBeenDestroyed'];
+    $hasMoonDestructionAttempt = $params['hasMoonDestructionAttempt'];
+
+    $targetTypeLabelContent = $_Lang['BR_Target_'.$fleetEndType];
+
+    if (!$hasMoonDestructionAttempt) {
+        return $targetTypeLabelContent;
+    }
+
+    return buildDOMElementHTML([
+        'tagName' => 'span',
+        'attrs' => [
+            'style' => (
+                "color: " .
+                classNames([
+                    'green' => ($hasMoonBeenDestroyed === 1),
+                    'orange' => ($hasMoonBeenDestroyed !== 1),
+                ])
+            )
+        ],
+        'contentHTML' => $targetTypeLabelContent,
+    ]);
 }
 
 ?>

--- a/modules/flights/utils/factories/createCombatMessages.utils.php
+++ b/modules/flights/utils/factories/createCombatMessages.utils.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Factories;
+
+/**
+ * @param array $params
+ * @param string $params['reportID']
+ * @param string $params['combatResult']
+ * @param string $params['fleetRow']
+ */
+function createCombatResultForAlliedDefendersMessage($params) {
+    global $_Lang;
+
+    $combatResult = $params['combatResult'];
+    $fleetRow = $params['fleetRow'];
+
+    $message = [
+        'msg_id' => '075',
+        'args' => [
+            $params['reportID'],
+            (
+                $combatResult === COMBAT_ATK ?
+                    'red' :
+                    (
+                        $combatResult === COMBAT_DRAW ?
+                        'orange' :
+                        'green'
+                    )
+            ),
+            $fleetRow['fleet_end_galaxy'],
+            $fleetRow['fleet_end_system'],
+            $fleetRow['fleet_end_planet'],
+            $_Lang['BR_Target_'.$fleetRow['fleet_end_type']],
+
+        ],
+    ];
+
+    return $message;
+}
+
+?>

--- a/modules/flights/utils/helpers/hasLostAnyDefenseSystem.utils.php
+++ b/modules/flights/utils/helpers/hasLostAnyDefenseSystem.utils.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Helpers;
+
+use UniEngine\Engine\Includes\Helpers\World\Elements;
+
+/**
+ * @param array $params
+ * @param array $params['originalShips'] Ships that have participated in the combat
+ * @param array $params['postCombatShips'] Ships that have survived the combat
+ */
+function hasLostAnyDefenseSystem($params) {
+    $originalShips = $params['originalShips'];
+    $postCombatShips = $params['postCombatShips'];
+
+    if (empty($originalShips[0])) {
+        return false;
+    }
+
+    $hasLostAnyDefenseSystems = false;
+
+    foreach ($originalShips[0] as $shipID => $shipOriginalCount) {
+        if (!Elements\isDefenseSystem($shipID)) {
+            continue;
+        }
+
+        $shipPostCombatCount = (
+            isset($postCombatShips[0][$shipID]) ?
+                $postCombatShips[0][$shipID] :
+                0
+        );
+
+        if ($shipPostCombatCount >= $shipOriginalCount) {
+            continue;
+        }
+
+        $hasLostAnyDefenseSystems = true;
+
+        break;
+    }
+
+    return $hasLostAnyDefenseSystems;
+}
+
+?>

--- a/modules/flights/utils/helpers/index.php
+++ b/modules/flights/utils/helpers/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>


### PR DESCRIPTION
## Summary:

Certain actions like pillage storage capacity calculation, fleet row updates aggregation & development log updates aggregation are all common to all three types of attacks (Solo, United, Destruction), however they all have these actions duplicated in the code. These things should all be shared, one way or the other.

## Changelog:

- [x] Export attacker(s) message creation into a separate function
    - [x] Function export (as utility)
    - [x] Use in Regular attack
    - [x] Use in Group attack (ACS)
    - [x] Use in Moon destruction
- [x] Export allied defender(s) message creation into a separate function
    - [x] Function export (as utility)
    - [x] Use in Regular attack
    - [x] Use in Group attack (ACS)
    - [x] Use in Moon destruction
- [x] Export main defender message creation into a separate function
    - [x] Function export (as utility)
    - [x] Use in Regular attack
    - [x] Use in Group attack (ACS)
    - [x] Use in Moon destruction
- [x] Investigate whether fleet destroyed by moon should be counted as "Aggressor lost"
    - The answer is `NO`, this counter represents the losses in combat. Including fleet destruction "by the moon" would obscure that, so for now let's leave it be.
- [x] Investigate whether fleet destroyed by moon should be included in debris field creation
    - The answer is `NO`, there should be no debris field created when the fleet gets destroyed "by the moon".

## Related issues or PRs:

- #91 
