### PR TITLE
Refactor fleet missions' code | Part 09 | Defense systems rebuild

### DIFF
--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -5,8 +5,8 @@ use UniEngine\Engine\Modules\Flights;
 
 function MissionCaseAttack($FleetRow, &$_FleetCache)
 {
-    global    $_EnginePath, $_Vars_Prices, $_Lang, $_Vars_GameElements, $_Vars_ElementCategories, $_GameConfig, $UserStatsData, $UserDev_Log, $IncludeCombatEngine,
-            $HPQ_PlanetUpdatedFields;
+    global $_EnginePath, $_Vars_Prices, $_Vars_GameElements, $_Vars_ElementCategories,
+        $_GameConfig, $UserStatsData, $UserDev_Log, $IncludeCombatEngine, $HPQ_PlanetUpdatedFields;
 
     $Return = array();
     $Now = time();

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -1,5 +1,6 @@
 <?php
 
+use UniEngine\Engine\Includes\Helpers\Common\Collections;
 use UniEngine\Engine\Modules\Flights;
 
 function MissionCaseDestruction($FleetRow, &$_FleetCache)
@@ -285,7 +286,6 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
         $DefShips        = $Combat['DefenderShips'];
         $AtkLost        = $Combat['AtkLose'];
         $DefLost        = $Combat['DefLose'];
-        $DefSysLost        = $Combat['DefSysLost'];
         $ShotDown        = $Combat['ShotDown'];
 
         $QryUpdateFleets = [];
@@ -515,47 +515,25 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
 
         // Parse result data - Defenders
         $i = 1;
-        if(!empty($DefendingFleets))
-        {
-            foreach($DefendingFleets as $User => $Ships)
-            {
-                if($User == 0)
-                {
-                    if($MoonHasBeenDestroyed !== 1)
-                    {
-                        $DefSysLostIDs = array_keys($DefSysLost);
-                        $DefSysLostIDs[] = -1;
+        if (!empty($DefendingFleets)) {
+            foreach ($DefendingFleets as $User => $Ships) {
+                if ($User == 0) {
+                    if ($MoonHasBeenDestroyed !== 1) {
+                        $rebuiltDefenseSystems = Flights\Utils\Calculations\calculateUnitsRebuild([
+                            'originalShips' => $DefendingFleets[0],
+                            'postCombatShips' => $DefShips[0],
+                            'fleetRow' => $FleetRow,
+                            'targetUser' => $TargetUser,
+                        ]);
 
-                        foreach($Ships as $ID => $Count)
-                        {
-                            if(in_array($ID, $DefSysLostIDs))
-                            {
-                                $Count = $DefShips[0][$ID];
-                                $Chance = mt_rand(60, 80 + (($TargetUser['engineer_time'] >= $FleetRow['fleet_start_time']) ? 20 : 0));
-                                $Fluctuation = mt_rand(-11, 11);
-                                if($Fluctuation > 0)
-                                {
-                                    $Fluctuation = 0;
-                                }
-                                $rebuiltDefenseSystems[$ID] = round($DefSysLost[$ID] * (($Chance + $Fluctuation) / 100));
-                                $Count += $rebuiltDefenseSystems[$ID];
-                                if($DefendingFleets[0][$ID] < $Count)
-                                {
-                                    $Count = $DefendingFleets[0][$ID];
-                                }
-                                unset($DefSysLost[$ID]);
-                            }
-                            else
-                            {
-                                $Count = $DefShips[0][$ID];
-                            }
-                            if($Count == 0)
-                            {
+                        foreach ($Ships as $ID => $Count) {
+                            $Count = ($DefShips[0][$ID] + $rebuiltDefenseSystems[$ID]);
+
+                            if ($Count == 0) {
                                 $Count = '0';
                             }
                             $TargetPlanet[$_Vars_GameElements[$ID]] = $Count;
-                            if($Count < $DefendingFleets[0][$ID])
-                            {
+                            if ($Count < $DefendingFleets[0][$ID]) {
                                 $UserDev_UpPl[] = $ID.','.($DefendingFleets[0][$ID] - $Count);
                                 $_FleetCache['updatePlanets'][$TargetPlanet['id']] = true;
                                 $HPQ_PlanetUpdatedFields[] = $_Vars_GameElements[$ID];
@@ -1126,7 +1104,7 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                 'fleetRow' => $FleetRow,
                 'rebuiltElements' => (
                     !$MoonHasBeenDestroyed ?
-                    $rebuiltDefenseSystems :
+                    Collections\compact($rebuiltDefenseSystems) :
                     []
                 ),
                 'hasMoonBeenDestroyed' => $MoonHasBeenDestroyed,

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -5,8 +5,9 @@ use UniEngine\Engine\Modules\Flights;
 
 function MissionCaseDestruction($FleetRow, &$_FleetCache)
 {
-    global    $_EnginePath, $_User, $_Vars_Prices, $_Lang, $_Vars_GameElements, $_Vars_ElementCategories, $_GameConfig, $ChangeCoordinatesForFleets,
-            $UserStatsData, $UserDev_Log, $IncludeCombatEngine, $HPQ_PlanetUpdatedFields, $GlobalParsedTasks;
+    global $_EnginePath, $_User, $_Vars_Prices, $_Vars_GameElements, $_Vars_ElementCategories,
+        $_GameConfig, $ChangeCoordinatesForFleets, $UserStatsData, $UserDev_Log,
+        $IncludeCombatEngine, $HPQ_PlanetUpdatedFields, $GlobalParsedTasks;
 
     $DEATHSTAR_ELEMENT_ID = 214;
 

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -1,5 +1,6 @@
 <?php
 
+use UniEngine\Engine\Includes\Helpers\Common\Collections;
 use UniEngine\Engine\Modules\Flights;
 
 function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
@@ -379,7 +380,6 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
         $DefShips            = $Combat['DefenderShips'];
         $AtkLost            = $Combat['AtkLose'];
         $DefLost            = $Combat['DefLose'];
-        $DefSysLost            = $Combat['DefSysLost'];
         $ShotDown            = $Combat['ShotDown'];
         $ForceContribution    = $Combat['ForceContribution'];
 
@@ -527,45 +527,24 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
         $rebuiltDefenseSystems = [];
 
         // Parse result data - Defenders
-        if(!empty($DefendingFleets))
-        {
-            foreach($DefendingFleets as $User => $Ships)
-            {
-                if($User == 0)
-                {
-                    $DefSysLostIDs = array_keys($DefSysLost);
-                    $DefSysLostIDs[] = -1;
+        if (!empty($DefendingFleets)) {
+            foreach ($DefendingFleets as $User => $Ships) {
+                if($User == 0) {
+                    $rebuiltDefenseSystems = Flights\Utils\Calculations\calculateUnitsRebuild([
+                        'originalShips' => $DefendingFleets[0],
+                        'postCombatShips' => $DefShips[0],
+                        'fleetRow' => $FleetRow,
+                        'targetUser' => $TargetUser,
+                    ]);
 
-                    foreach($Ships as $ID => $Count)
-                    {
-                        if(in_array($ID, $DefSysLostIDs))
-                        {
-                            $Count = $DefShips[0][$ID];
-                            $Chance = mt_rand(60, 80 + (($TargetUser['engineer_time'] >= $FleetRow['fleet_start_time']) ? 20 : 0));
-                            $Fluctuation = mt_rand(-11, 11);
-                            if($Fluctuation > 0)
-                            {
-                                $Fluctuation = 0;
-                            }
-                            $rebuiltDefenseSystems[$ID] = round($DefSysLost[$ID] * (($Chance + $Fluctuation) / 100));
-                            $Count += $rebuiltDefenseSystems[$ID];
-                            if($DefendingFleets[0][$ID] < $Count)
-                            {
-                                $Count = $DefendingFleets[0][$ID];
-                            }
-                            unset($DefSysLost[$ID]);
-                        }
-                        else
-                        {
-                            $Count = $DefShips[0][$ID];
-                        }
-                        if($Count == 0)
-                        {
+                    foreach($Ships as $ID => $Count) {
+                        $Count = ($DefShips[0][$ID] + $rebuiltDefenseSystems[$ID]);
+
+                        if ($Count == 0) {
                             $Count = '0';
                         }
                         $TargetPlanet[$_Vars_GameElements[$ID]] = $Count;
-                        if($Count < $DefendingFleets[0][$ID])
-                        {
+                        if ($Count < $DefendingFleets[0][$ID]) {
                             $UserDev_UpPl[] = $ID.','.($DefendingFleets[0][$ID] - $Count);
                             $_FleetCache['updatePlanets'][$TargetPlanet['id']] = true;
                             $HPQ_PlanetUpdatedFields[] = $_Vars_GameElements[$ID];
@@ -1290,7 +1269,7 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 'report' => $CreatedReport,
                 'combatResult' => $Result,
                 'fleetRow' => $FleetRow,
-                'rebuiltElements' => $rebuiltDefenseSystems,
+                'rebuiltElements' => Collections\compact($rebuiltDefenseSystems),
                 'hasLostAnyDefenseSystems' => Flights\Utils\Helpers\hasLostAnyDefenseSystem([
                     'originalShips' => $DefendingFleets,
                     'postCombatShips' => $DefShips,

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -5,8 +5,8 @@ use UniEngine\Engine\Modules\Flights;
 
 function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
 {
-    global    $_EnginePath, $_Vars_Prices, $_Lang, $_Vars_GameElements, $_Vars_ElementCategories, $_GameConfig, $UserStatsData, $UserDev_Log, $IncludeCombatEngine,
-            $HPQ_PlanetUpdatedFields;
+    global $_EnginePath, $_Vars_Prices, $_Vars_GameElements, $_Vars_ElementCategories,
+        $_GameConfig, $UserStatsData, $UserDev_Log, $IncludeCombatEngine, $HPQ_PlanetUpdatedFields;
 
     $Return = array();
     $Now = time();

--- a/includes/helpers/common/collections.functions.php
+++ b/includes/helpers/common/collections.functions.php
@@ -40,6 +40,16 @@ function without($collection, $excludedElement) {
     });
 }
 
+function map($collection, $iteratee) {
+    $mappedObject = [];
+
+    foreach ($collection as $key => $value) {
+        $mappedObject[$key] = $iteratee($value, $key);
+    }
+
+    return $mappedObject;
+}
+
 function mapEntries($collection, $iteratee) {
     $mappedObject = [];
 

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -9,6 +9,7 @@ call_user_func(function () {
     include($includePath . './utils/calculations/calculatePillageFactor.utils.php');
     include($includePath . './utils/calculations/calculatePillageStorage.utils.php');
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
+    include($includePath . './utils/calculations/calculateUnitsRebuild.utils.php');
     include($includePath . './utils/factories/createCombatMessages.utils.php');
     include($includePath . './utils/factories/createFleetDevelopmentLogEntries.utils.php');
     include($includePath . './utils/factories/createFleetUpdateEntry.utils.php');

--- a/modules/flights/utils/calculations/calculateUnitsRebuild.utils.php
+++ b/modules/flights/utils/calculations/calculateUnitsRebuild.utils.php
@@ -80,9 +80,12 @@ function _calculateRebuildPercentage($params) {
         )
     );
     $shipRebuildChanceFluctuation = min(mt_rand(-15, 15), 0);
-    $shipRebuildPercentage = min(
-        ($shipRebuildChance + $shipRebuildChanceFluctuation),
-        100
+    $shipRebuildPercentage = max(
+        min(
+            ($shipRebuildChance + $shipRebuildChanceFluctuation),
+            100
+        ),
+        0
     );
 
     return $shipRebuildPercentage;

--- a/modules/flights/utils/calculations/calculateUnitsRebuild.utils.php
+++ b/modules/flights/utils/calculations/calculateUnitsRebuild.utils.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Calculations;
+
+use UniEngine\Engine\Includes\Helpers\Common\Collections;
+use UniEngine\Engine\Includes\Helpers\World\Elements;
+
+/**
+ * @param array $params
+ * @param array $params['originalShips']
+ * @param array $params['postCombatShips']
+ * @param array $params['fleetRow']
+ * @param array $params['targetUser']
+ *
+ * @todo The algorithm implemented below does not represent the real life behaviour
+ *       of Ogame-like rebuild algorithm, which calculates the rebuild chance
+ *       for each singular lost unit separately. This approach would lead to
+ *       bad performance in high unit count scenarios.
+ *       Investigate whether it's possible to apply statistical methods to achieve
+ *       similar to Ogame-like games results.
+ */
+function calculateUnitsRebuild($params) {
+    $originalShips = $params['originalShips'];
+    $postCombatShips = $params['postCombatShips'];
+    $fleetRow = $params['fleetRow'];
+    $targetUser = $params['targetUser'];
+
+    $isOfficerEngineerActive = ($targetUser['engineer_time'] >= $fleetRow['fleet_start_time']);
+
+    return Collections\map(
+        $originalShips,
+        function ($shipOriginalCount, $shipID) use ($postCombatShips, $isOfficerEngineerActive) {
+            if (!Elements\isDefenseSystem($shipID)) {
+                return 0;
+            }
+
+            $shipPostCombatCount = (
+                isset($postCombatShips[$shipID]) ?
+                    $postCombatShips[$shipID] :
+                    0
+            );
+            $shipLostCount = ($shipOriginalCount - $shipPostCombatCount);
+
+            if ($shipLostCount === 0) {
+                return 0;
+            }
+
+            $shipRebuildPercentage = _calculateRebuildPercentage([
+                'isOfficerEngineerActive' => $isOfficerEngineerActive,
+            ]);
+
+            return round(
+                $shipLostCount *
+                ($shipRebuildPercentage / 100)
+            );
+        }
+    );
+}
+
+/**
+ * @param array $params
+ * @param boolean $params['isOfficerEngineerActive']
+ */
+function _calculateRebuildPercentage($params) {
+    $isOfficerEngineerActive = $params['isOfficerEngineerActive'];
+
+    $CONST_REBUILD_CHANCE_BASE_MIN = 60;
+    $CONST_REBUILD_CHANCE_BASE_MAX = 80;
+    $CONST_REBUILD_CHANCE_BONUS_MAX_OFFICER_ENGINEER = 20;
+
+    $shipRebuildChance = mt_rand(
+        $CONST_REBUILD_CHANCE_BASE_MIN,
+        (
+            $CONST_REBUILD_CHANCE_BASE_MAX +
+            (
+                $isOfficerEngineerActive ?
+                $CONST_REBUILD_CHANCE_BONUS_MAX_OFFICER_ENGINEER :
+                0
+            )
+        )
+    );
+    $shipRebuildChanceFluctuation = min(mt_rand(-15, 15), 0);
+    $shipRebuildPercentage = min(
+        ($shipRebuildChance + $shipRebuildChanceFluctuation),
+        100
+    );
+
+    return $shipRebuildPercentage;
+}
+
+
+?>


### PR DESCRIPTION
## Summary:

When calculating the result of an attack, all three missions (attack, destruction & group attack) have separate, hardcoded implementation of defender's defense systems rebuilding. This should be moved to a shared utility to prevent code duplication & unify their behaviour (especially since there's a difference right now, looks like a simple miss type from the old days).

## Changelog:

- [x] Export defense systems rebuild calculation into a separate function
    - [x] Function export (as utility)
    - [x] Use in Regular attack
    - [x] Use in Group attack (ACS)
    - [x] Use in Moon destruction

## Related issues or PRs:

- #91 
