### PR TITLE
Refactor fleet missions' code | Part 10 | Defenders' details aggregation

### DIFF
--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -143,73 +143,38 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
         }
 
         // Select All Defending Fleets on the Orbit from $_FleetCache
-        if(!empty($_FleetCache['defFleets'][$FleetRow['fleet_end_id']]))
-        {
+        if (!empty($_FleetCache['defFleets'][$FleetRow['fleet_end_id']])) {
+            $_TempCache = [
+                'MoraleCache' => [],
+            ];
+
             $i = 1;
-            foreach($_FleetCache['defFleets'][$FleetRow['fleet_end_id']] as $FleetData)
-            {
-                if($_FleetCache['fleetRowStatus'][$FleetData['fleet_id']]['isDestroyed'] !== true)
-                {
-                    $DefendingFleets[$i] = String2Array($FleetData['fleet_array']);
-                    $DefendingFleetID[$i] = $FleetData['fleet_id'];
-                    $DefendingTechs[$i] = Flights\Utils\Initializers\initCombatTechnologiesMap([
-                        'user' => $FleetData,
-                    ]);
-                    $DefendersData[$i] = array
-                    (
-                        'id' => $FleetData['fleet_owner'],
-                        'username' => $FleetData['username'],
-                        'techs' => Array2String($DefendingTechs[$i]),
-                        'pos' => "{$FleetData['fleet_start_galaxy']}:{$FleetData['fleet_start_system']}:{$FleetData['fleet_start_planet']}"
-                    );
-                    if(!empty($FleetData['ally_tag']))
-                    {
-                        $DefendersData[$i]['ally'] = $FleetData['ally_tag'];
-                    }
-                    if(!in_array($FleetData['fleet_owner'], $DefendersIDs))
-                    {
-                        $DefendersIDs[] = $FleetData['fleet_owner'];
-                    }
-                    $DefendingFleetOwners[$FleetData['fleet_id']] = $FleetData['fleet_owner'];
 
-                    if(MORALE_ENABLED)
-                    {
-                        if(empty($_TempCache['MoraleCache'][$FleetData['fleet_owner']]))
-                        {
-                            if(!empty($_FleetCache['MoraleCache'][$FleetData['fleet_owner']]))
-                            {
-                                $FleetData['morale_level'] = $_FleetCache['MoraleCache'][$FleetData['fleet_owner']]['level'];
-                                $FleetData['morale_droptime'] = $_FleetCache['MoraleCache'][$FleetData['fleet_owner']]['droptime'];
-                                $FleetData['morale_lastupdate'] = $_FleetCache['MoraleCache'][$FleetData['fleet_owner']]['lastupdate'];
-                            }
-                            Morale_ReCalculate($FleetData, $FleetRow['fleet_start_time']);
-                            $DefendersData[$i]['morale'] = $FleetData['morale_level'];
-                            $DefendersData[$i]['moralePoints'] = $FleetData['morale_points'];
-
-                            $_TempCache['MoraleCache'][$FleetData['fleet_owner']] = array
-                            (
-                                'level' => $FleetData['morale_level'],
-                                'points' => $FleetData['morale_points']
-                            );
-                        }
-                        else
-                        {
-                            $DefendersData[$i]['morale'] = $_TempCache['MoraleCache'][$FleetData['fleet_owner']]['level'];
-                            $DefendersData[$i]['moralePoints'] = $_TempCache['MoraleCache'][$FleetData['fleet_owner']]['points'];
-                        }
-
-                        $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
-                            'moraleLevel' => $DefendersData[$i]['morale'],
-                        ]);
-
-                        $DefendingTechs[$i] = array_merge(
-                            $DefendingTechs[$i],
-                            $moraleCombatModifiers
-                        );
-                    }
-
-                    $i += 1;
+            foreach ($_FleetCache['defFleets'][$FleetRow['fleet_end_id']] as $fleetData) {
+                if ($_FleetCache['fleetRowStatus'][$fleetData['fleet_id']]['isDestroyed']) {
+                    continue;
                 }
+
+                $defenderDetails = Flights\Utils\Initializers\initDefenderDetails([
+                    'combatTimestamp' => $FleetRow['fleet_start_time'],
+                    'fleetData' => $fleetData,
+                    'fleetCache' => &$_FleetCache,
+                    'localCache' => &$_TempCache,
+                ]);
+                $defenderUserID = $defenderDetails['userData']['id'];
+
+                $DefendingFleets[$i] = $defenderDetails['ships'];
+                $DefendingFleetID[$i] = $defenderDetails['fleetID'];
+                $DefendingTechs[$i] = $defenderDetails['combatTechnologies'];
+                $DefendersData[$i] = $defenderDetails['userData'];
+
+                $DefendingFleetOwners[$defenderDetails['fleetID']] = $defenderUserID;
+
+                if (!in_array($defenderUserID, $DefendersIDs)) {
+                    $DefendersIDs[] = $defenderUserID;
+                }
+
+                $i += 1;
             }
         }
 

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -77,73 +77,38 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
         }
 
         // Select All Defending Fleets on the Orbit from $_FleetCache
-        if(!empty($_FleetCache['defFleets'][$FleetRow['fleet_end_id']]))
-        {
+        if (!empty($_FleetCache['defFleets'][$FleetRow['fleet_end_id']])) {
+            $_TempCache = [
+                'MoraleCache' => [],
+            ];
+
             $i = 1;
-            foreach($_FleetCache['defFleets'][$FleetRow['fleet_end_id']] as $FleetData)
-            {
-                if($_FleetCache['fleetRowStatus'][$FleetData['fleet_id']]['isDestroyed'] !== true)
-                {
-                    $DefendingFleets[$i] = String2Array($FleetData['fleet_array']);
-                    $DefendingFleetID[$i] = $FleetData['fleet_id'];
-                    $DefendingTechs[$i] = Flights\Utils\Initializers\initCombatTechnologiesMap([
-                        'user' => $FleetData,
-                    ]);
-                    $DefendersData[$i] = array
-                    (
-                        'id' => $FleetData['fleet_owner'],
-                        'username' => $FleetData['username'],
-                        'techs' => Array2String($DefendingTechs[$i]),
-                        'pos' => "{$FleetData['fleet_start_galaxy']}:{$FleetData['fleet_start_system']}:{$FleetData['fleet_start_planet']}"
-                    );
-                    if(!empty($FleetData['ally_tag']))
-                    {
-                        $DefendersData[$i]['ally'] = $FleetData['ally_tag'];
-                    }
-                    if(!in_array($FleetData['fleet_owner'], $DefendersIDs))
-                    {
-                        $DefendersIDs[] = $FleetData['fleet_owner'];
-                    }
-                    $DefendingFleetOwners[$FleetData['fleet_id']] = $FleetData['fleet_owner'];
 
-                    if(MORALE_ENABLED)
-                    {
-                        if(empty($_TempCache['MoraleCache'][$FleetData['fleet_owner']]))
-                        {
-                            if(!empty($_FleetCache['MoraleCache'][$FleetData['fleet_owner']]))
-                            {
-                                $FleetData['morale_level'] = $_FleetCache['MoraleCache'][$FleetData['fleet_owner']]['level'];
-                                $FleetData['morale_droptime'] = $_FleetCache['MoraleCache'][$FleetData['fleet_owner']]['droptime'];
-                                $FleetData['morale_lastupdate'] = $_FleetCache['MoraleCache'][$FleetData['fleet_owner']]['lastupdate'];
-                            }
-                            Morale_ReCalculate($FleetData, $FleetRow['fleet_start_time']);
-                            $DefendersData[$i]['morale'] = $FleetData['morale_level'];
-                            $DefendersData[$i]['moralePoints'] = $FleetData['morale_points'];
-
-                            $_TempCache['MoraleCache'][$FleetData['fleet_owner']] = array
-                            (
-                                'level' => $FleetData['morale_level'],
-                                'points' => $FleetData['morale_points']
-                            );
-                        }
-                        else
-                        {
-                            $DefendersData[$i]['morale'] = $_TempCache['MoraleCache'][$FleetData['fleet_owner']]['level'];
-                            $DefendersData[$i]['moralePoints'] = $_TempCache['MoraleCache'][$FleetData['fleet_owner']]['points'];
-                        }
-
-                        $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
-                            'moraleLevel' => $DefendersData[$i]['morale'],
-                        ]);
-
-                        $DefendingTechs[$i] = array_merge(
-                            $DefendingTechs[$i],
-                            $moraleCombatModifiers
-                        );
-                    }
-
-                    $i += 1;
+            foreach ($_FleetCache['defFleets'][$FleetRow['fleet_end_id']] as $fleetData) {
+                if ($_FleetCache['fleetRowStatus'][$fleetData['fleet_id']]['isDestroyed']) {
+                    continue;
                 }
+
+                $defenderDetails = Flights\Utils\Initializers\initDefenderDetails([
+                    'combatTimestamp' => $FleetRow['fleet_start_time'],
+                    'fleetData' => $fleetData,
+                    'fleetCache' => &$_FleetCache,
+                    'localCache' => &$_TempCache,
+                ]);
+                $defenderUserID = $defenderDetails['userData']['id'];
+
+                $DefendingFleets[$i] = $defenderDetails['ships'];
+                $DefendingFleetID[$i] = $defenderDetails['fleetID'];
+                $DefendingTechs[$i] = $defenderDetails['combatTechnologies'];
+                $DefendersData[$i] = $defenderDetails['userData'];
+
+                $DefendingFleetOwners[$defenderDetails['fleetID']] = $defenderUserID;
+
+                if (!in_array($defenderUserID, $DefendersIDs)) {
+                    $DefendersIDs[] = $defenderUserID;
+                }
+
+                $i += 1;
             }
         }
 

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -16,6 +16,7 @@ call_user_func(function () {
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');
     include($includePath . './utils/fleetCache/updateUserStats.utils.php');
     include($includePath . './utils/helpers/hasLostAnyDefenseSystem.utils.php');
+    include($includePath . './utils/initializers/defenderDetails.utils.php');
     include($includePath . './utils/initializers/technologies.utils.php');
     include($includePath . './utils/initializers/userStats.utils.php');
     include($includePath . './utils/modifiers/calculateMoraleModifiers.utils.php');

--- a/modules/flights/utils/initializers/defenderDetails.utils.php
+++ b/modules/flights/utils/initializers/defenderDetails.utils.php
@@ -6,15 +6,17 @@ use UniEngine\Engine\Modules\Flights;
 
 /**
  * @param array $params
- * @param ref $params['fleetData']
+ * @param string $params['combatTimestamp']
+ * @param array $params['fleetData']
  * @param ref $params['fleetCache']
  * @param ref $params['localCache']
  */
 function initDefenderDetails($params) {
-    $fleetData = &$params['fleetData'];
+    $combatTimestamp = $params['combatTimestamp'];
+    $fleetData = $params['fleetData'];
     $fleetOwnerID = $fleetData['fleet_owner'];
-    $fleetCache = &$fleetData['fleetCache'];
-    $localCache = &$fleetData['localCache'];
+    $fleetCache = &$params['fleetCache'];
+    $localCache = &$params['localCache'];
 
     $combatTechnologies = Flights\Utils\Initializers\initCombatTechnologiesMap([
         'user' => $fleetData,
@@ -37,13 +39,13 @@ function initDefenderDetails($params) {
                 $fleetData['morale_droptime'] = $fleetCache['MoraleCache'][$fleetOwnerID]['droptime'];
                 $fleetData['morale_lastupdate'] = $fleetCache['MoraleCache'][$fleetOwnerID]['lastupdate'];
             }
-            Morale_ReCalculate($fleetData, $fleetData['fleet_start_time']);
+            Morale_ReCalculate($fleetData, $combatTimestamp);
             $userData['morale'] = $fleetData['morale_level'];
             $userData['moralePoints'] = $fleetData['morale_points'];
 
             $localCache['MoraleCache'][$fleetOwnerID] = [
-                'level' => $userData['morale_level'],
-                'points' => $userData['morale_points']
+                'level' => $fleetData['morale_level'],
+                'points' => $fleetData['morale_points']
             ];
         } else {
             $userData['morale'] = $localCache['MoraleCache'][$fleetOwnerID]['level'];
@@ -68,9 +70,7 @@ function initDefenderDetails($params) {
     ];
 }
 
-function _createFleetCoordinatesString($params) {
-    $fleetData = $params['fleetData'];
-
+function _createFleetCoordinatesString($fleetData) {
     return "{$fleetData['fleet_start_galaxy']}:{$fleetData['fleet_start_system']}:{$fleetData['fleet_start_planet']}";
 }
 

--- a/modules/flights/utils/initializers/defenderDetails.utils.php
+++ b/modules/flights/utils/initializers/defenderDetails.utils.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Initializers;
+
+use UniEngine\Engine\Modules\Flights;
+
+/**
+ * @param array $params
+ * @param ref $params['fleetData']
+ * @param ref $params['fleetCache']
+ * @param ref $params['localCache']
+ */
+function initDefenderDetails($params) {
+    $fleetData = &$params['fleetData'];
+    $fleetOwnerID = $fleetData['fleet_owner'];
+    $fleetCache = &$fleetData['fleetCache'];
+    $localCache = &$fleetData['localCache'];
+
+    $combatTechnologies = Flights\Utils\Initializers\initCombatTechnologiesMap([
+        'user' => $fleetData,
+    ]);
+    $userData = [
+        'id' => $fleetOwnerID,
+        'username' => $fleetData['username'],
+        'techs' => Array2String($combatTechnologies),
+        'pos' => _createFleetCoordinatesString($fleetData),
+    ];
+
+    if (!empty($fleetData['ally_tag'])) {
+        $userData['ally'] = $fleetData['ally_tag'];
+    }
+
+    if (MORALE_ENABLED) {
+        if (empty($localCache['MoraleCache'][$fleetOwnerID])) {
+            if (!empty($fleetCache['MoraleCache'][$fleetOwnerID])) {
+                $fleetData['morale_level'] = $fleetCache['MoraleCache'][$fleetOwnerID]['level'];
+                $fleetData['morale_droptime'] = $fleetCache['MoraleCache'][$fleetOwnerID]['droptime'];
+                $fleetData['morale_lastupdate'] = $fleetCache['MoraleCache'][$fleetOwnerID]['lastupdate'];
+            }
+            Morale_ReCalculate($fleetData, $fleetData['fleet_start_time']);
+            $userData['morale'] = $fleetData['morale_level'];
+            $userData['moralePoints'] = $fleetData['morale_points'];
+
+            $localCache['MoraleCache'][$fleetOwnerID] = [
+                'level' => $userData['morale_level'],
+                'points' => $userData['morale_points']
+            ];
+        } else {
+            $userData['morale'] = $localCache['MoraleCache'][$fleetOwnerID]['level'];
+            $userData['moralePoints'] = $localCache['MoraleCache'][$fleetOwnerID]['points'];
+        }
+
+        $moraleCombatModifiers = Flights\Utils\Modifiers\calculateMoraleCombatModifiers([
+            'moraleLevel' => $userData['morale'],
+        ]);
+
+        $combatTechnologies = array_merge(
+            $combatTechnologies,
+            $moraleCombatModifiers
+        );
+    }
+
+    return [
+        'fleetID' => $fleetData['fleet_id'],
+        'ships' => String2Array($fleetData['fleet_array']),
+        'combatTechnologies' => $combatTechnologies,
+        'userData' => $userData,
+    ];
+}
+
+function _createFleetCoordinatesString($params) {
+    $fleetData = $params['fleetData'];
+
+    return "{$fleetData['fleet_start_galaxy']}:{$fleetData['fleet_start_system']}:{$fleetData['fleet_start_planet']}";
+}
+
+?>


### PR DESCRIPTION
## Summary:

All three possible combat missions (MissionAttack, MissionDestruction & MissionGroupAttack) share the same mechanism of defenders' details initialisation and aggregation. This mechanism should be implemented in just one place and shared among them.

## Changelog:

- [x] Export defenders' details initialisation into a separate function
    - [x] Function export (as utility)
    - [x] Use in Regular attack
    - [x] Use in Group attack (ACS)
    - [x] Use in Moon destruction

## Related issues or PRs:

- #91 
