### PR TITLE
Refactor fleet missions' code | Part 11 | Combat result stats aggregation

### DIFF
--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -750,41 +750,13 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
         }
 
         // Update battle stats & set Battle Report colors
-        if(!$IsAllyFight)
-        {
-            if($Result === COMBAT_ATK)
-            {
-                foreach($AttackersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_won'] += 1;
-                }
-                foreach($DefendersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_lost'] += 1;
-                }
-            }
-            elseif($Result === COMBAT_DRAW)
-            {
-                foreach($AttackersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_draw'] += 1;
-                }
-                foreach($DefendersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_draw'] += 1;
-                }
-            }
-            elseif($Result === COMBAT_DEF)
-            {
-                foreach($AttackersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_lost'] += 1;
-                }
-                foreach($DefendersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_won'] += 1;
-                }
-            }
+        if (!$IsAllyFight) {
+            Flights\Utils\FleetCache\applyCombatResultStats([
+                'userStats' => &$UserStatsData,
+                'combatResultType' => $Result,
+                'attackerIDs' => $AttackersIDs,
+                'defenderIDs' => $DefendersIDs,
+            ]);
 
             // Update User Destroyed & Lost Stats
             Flights\Utils\FleetCache\applyCombatUnitStats([

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -927,41 +927,13 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
         }
 
         // Update battle stats & set Battle Report colors
-        if(!$IsAllyFight)
-        {
-            if($Result === COMBAT_ATK)
-            {
-                foreach($AttackersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_won'] += 1;
-                }
-                foreach($DefendersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_lost'] += 1;
-                }
-            }
-            elseif($Result === COMBAT_DRAW)
-            {
-                foreach($AttackersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_draw'] += 1;
-                }
-                foreach($DefendersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_draw'] += 1;
-                }
-            }
-            elseif($Result === COMBAT_DEF)
-            {
-                foreach($AttackersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_lost'] += 1;
-                }
-                foreach($DefendersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_won'] += 1;
-                }
-            }
+        if (!$IsAllyFight) {
+            Flights\Utils\FleetCache\applyCombatResultStats([
+                'userStats' => &$UserStatsData,
+                'combatResultType' => $Result,
+                'attackerIDs' => $AttackersIDs,
+                'defenderIDs' => $DefendersIDs,
+            ]);
 
             // Update User Destroyed & Lost Stats
             Flights\Utils\FleetCache\applyCombatUnitStats([

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -1084,7 +1084,6 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
             {
                 foreach($AttackersIDs as $UserID)
                 {
-                    $UserStatsData[$UserID]['raids_won'] += 1;
                     if($AttackersCount > 1)
                     {
                         if(($ForceUsed_Array[$UserID] / $ForceUsed_Total) >= ACS_MINIMALFORCECONTRIBUTION)
@@ -1094,16 +1093,11 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                         }
                     }
                 }
-                foreach($DefendersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_lost'] += 1;
-                }
             }
             else if($Result === COMBAT_DRAW)
             {
                 foreach($AttackersIDs as $UserID)
                 {
-                    $UserStatsData[$UserID]['raids_draw'] += 1;
                     if($AttackersCount > 1)
                     {
                         if(($ForceUsed_Array[$UserID] / $ForceUsed_Total) >= ACS_MINIMALFORCECONTRIBUTION)
@@ -1112,20 +1106,14 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                         }
                     }
                 }
-                foreach($DefendersIDs as $UserID)
-                {
-                    $UserStatsData[$UserID]['raids_draw'] += 1;
-                }
             }
-            else if($Result === COMBAT_DEF)
-            {
-                foreach($AttackersIDs as $UserID){
-                    $UserStatsData[$UserID]['raids_lost'] += 1;
-                }
-                foreach($DefendersIDs as $UserID){
-                    $UserStatsData[$UserID]['raids_won'] += 1;
-                }
-            }
+
+            Flights\Utils\FleetCache\applyCombatResultStats([
+                'userStats' => &$UserStatsData,
+                'combatResultType' => $Result,
+                'attackerIDs' => $AttackersIDs,
+                'defenderIDs' => $DefendersIDs,
+            ]);
 
             // Update User Destroyed & Lost Stats
             Flights\Utils\FleetCache\applyCombatUnitStats([

--- a/modules/flights/utils/fleetCache/updateUserStats.utils.php
+++ b/modules/flights/utils/fleetCache/updateUserStats.utils.php
@@ -2,6 +2,7 @@
 
 namespace UniEngine\Engine\Modules\Flights\Utils\FleetCache;
 
+// use UniEngine\Engine\Common\Exceptions;
 use UniEngine\Engine\Includes\Helpers\World\Elements;
 
 abstract class WorldElementCounterType {
@@ -109,6 +110,63 @@ function applyCombatUnitStats($params) {
                 }
             }
         }
+    }
+}
+
+abstract class _CombatParticipantUserType {
+    const Attacker = 0;
+    const Defender = 1;
+}
+
+function _getCombatResultStatKey($combatResultType, $userType) {
+    switch ($combatResultType) {
+        case COMBAT_DRAW:
+            return 'raids_draw';
+        case COMBAT_ATK:
+            return (
+                $userType === _CombatParticipantUserType::Attacker ?
+                    'raids_won' :
+                    'raids_lost'
+            );
+        case COMBAT_DEF:
+            return (
+                $userType === _CombatParticipantUserType::Defender ?
+                    'raids_won' :
+                    'raids_lost'
+            );
+        default:
+            // throw new Exceptions\UniEngineException("Invalid combat result type '{$combatResultType}'");
+            return '';
+    }
+}
+
+/**
+ * @param array $params
+ * @param ref $params['userStats']
+ * @param string $params['combatResultType']
+ * @param array $params['attackerIDs']
+ * @param array $params['defenderIDs']
+ */
+function applyCombatResultStats($params) {
+    $userStats = &$params['userStats'];
+    $combatResultType = $params['combatResultType'];
+    $attackerIDs = $params['attackerIDs'];
+    $defenderIDs = $params['defenderIDs'];
+
+    $attackersCombatResultStatKey = _getCombatResultStatKey(
+        $combatResultType,
+        _CombatParticipantUserType::Attacker
+    );
+    $defendersCombatResultStatKey = _getCombatResultStatKey(
+        $combatResultType,
+        _CombatParticipantUserType::Defender
+    );
+
+    foreach ($attackerIDs as $userID) {
+        $userStats[$userID][$attackersCombatResultStatKey] += 1;
+    }
+    foreach ($defenderIDs as $userID) {
+        $userStats[$userID][$defendersCombatResultStatKey] += 1;
     }
 }
 


### PR DESCRIPTION
## Summary:

All three possible combat missions (MissionAttack, MissionDestruction & MissionGroupAttack) share the same mechanism of combat result stats aggregation (whether the fight was won, drawn or lost). This mechanism should be implemented in just one place and shared among them.

## Changelog:

- [x] Export combat result stats aggregation into a separate function
    - [x] Function export (as utility)
    - [x] Use in Regular attack
    - [x] Use in Group attack (ACS)
    - [x] Use in Moon destruction

## Related issues or PRs:

- #91 
