### PR TITLE
Refactor fleet missions' code | Part 12 | Combat morale updates

### DIFF
--- a/includes/functions/MissionCaseAttack.php
+++ b/includes/functions/MissionCaseAttack.php
@@ -98,14 +98,13 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
         }
 
         // MoraleSystem Init
-        if(MORALE_ENABLED)
-        {
-            if(!empty($_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]))
-            {
-                $FleetRow['morale_level'] = $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['level'];
-                $FleetRow['morale_droptime'] = $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['droptime'];
-                $FleetRow['morale_lastupdate'] = $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['lastupdate'];
-            }
+        if (MORALE_ENABLED) {
+            Flights\Utils\FleetCache\loadMoraleDataFromCache([
+                'destination' => &$FleetRow,
+                'fleetCache' => &$_FleetCache,
+                'userID' => $FleetRow['fleet_owner'],
+            ]);
+
             Morale_ReCalculate($FleetRow, $FleetRow['fleet_start_time']);
             $AttackersData[0]['morale'] = $FleetRow['morale_level'];
             $AttackersData[0]['moralePoints'] = $FleetRow['morale_points'];
@@ -119,14 +118,13 @@ function MissionCaseAttack($FleetRow, &$_FleetCache)
                 $moraleCombatModifiers
             );
 
-            if(!$IsAbandoned)
-            {
-                if(!empty($_FleetCache['MoraleCache'][$TargetUser['id']]))
-                {
-                    $TargetUser['morale_level'] = $_FleetCache['MoraleCache'][$TargetUser['id']]['level'];
-                    $TargetUser['morale_droptime'] = $_FleetCache['MoraleCache'][$TargetUser['id']]['droptime'];
-                    $TargetUser['morale_lastupdate'] = $_FleetCache['MoraleCache'][$TargetUser['id']]['lastupdate'];
-                }
+            if (!$IsAbandoned) {
+                Flights\Utils\FleetCache\loadMoraleDataFromCache([
+                    'destination' => &$TargetUser,
+                    'fleetCache' => &$_FleetCache,
+                    'userID' => $TargetUser['id'],
+                ]);
+
                 Morale_ReCalculate($TargetUser, $FleetRow['fleet_start_time']);
                 $DefendersData[0]['morale'] = $TargetUser['morale_level'];
                 $DefendersData[0]['moralePoints'] = $TargetUser['morale_points'];

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -789,80 +789,22 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
         }
 
         // Morale System
-        if(MORALE_ENABLED AND !$IsAbandoned AND !$IsAllyFight AND $IdleHours < (7 * 24))
-        {
-            $Morale_Factor = $FleetRow['morale_points'] / $TargetUser['morale_points'];
-            if($Morale_Factor < 1)
-            {
-                $Morale_Factor = pow($Morale_Factor, -1);
-                $Morale_AttackerStronger = false;
-            }
-            else
-            {
-                $Morale_AttackerStronger = true;
-            }
+        $reportMoraleEntries = [];
 
-            if($Morale_Factor > MORALE_MINIMALFACTOR)
-            {
-                if($Morale_AttackerStronger)
-                {
-                    $Morale_Update_Attacker_Type = MORALE_NEGATIVE;
-                    if($Result === COMBAT_DEF OR $Result === COMBAT_DRAW)
-                    {
-                        $Morale_Update_Defender_Type = MORALE_POSITIVE;
-                    }
-                }
-                else
-                {
-                    $Morale_Update_Attacker_Type = MORALE_POSITIVE;
-                }
+        if (MORALE_ENABLED AND !$IsAbandoned AND !$IsAllyFight AND $IdleHours < (7 * 24)) {
+            $moraleUpdate = Flights\Utils\Calculations\calculatePostCombatMoraleUpdates([
+                'combatResult' => $Result,
+                'fleetRow' => $FleetRow,
+                'attackersMorale' => [
+                    $FleetRow['fleet_owner'] => $FleetRow,
+                ],
+                'defendersMorale' => [
+                    $TargetUser['id'] => $TargetUser,
+                ],
+                'fleetCache' => &$_FleetCache,
+            ]);
 
-                $Morale_Updated = Morale_AddMorale($FleetRow, $Morale_Update_Attacker_Type, $Morale_Factor, 1, 1, $FleetRow['fleet_start_time']);
-                if($Morale_Updated)
-                {
-                    $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['level'] = $FleetRow['morale_level'];
-                    $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['droptime'] = $FleetRow['morale_droptime'];
-                    $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['lastupdate'] = $FleetRow['morale_lastupdate'];
-
-                    $ReportData['morale'][$FleetRow['fleet_owner']] = array
-                    (
-                        'usertype' => 'atk',
-                        'type' => $Morale_Update_Attacker_Type,
-                        'factor' => $Morale_Factor,
-                        'level' => $FleetRow['morale_level']
-                    );
-                }
-
-                if($Morale_Update_Defender_Type !== null)
-                {
-                    if($Result === COMBAT_DRAW)
-                    {
-                        $Morale_LevelFactor = 1/2;
-                        $Morale_TimeFactor = 1/2;
-                    }
-                    else
-                    {
-                        $Morale_LevelFactor = 1;
-                        $Morale_TimeFactor = 1;
-                    }
-
-                    $Morale_Updated = Morale_AddMorale($TargetUser, $Morale_Update_Defender_Type, $Morale_Factor, $Morale_LevelFactor, $Morale_TimeFactor, $FleetRow['fleet_start_time']);
-                    if($Morale_Updated)
-                    {
-                        $_FleetCache['MoraleCache'][$TargetUser['id']]['level'] = $TargetUser['morale_level'];
-                        $_FleetCache['MoraleCache'][$TargetUser['id']]['droptime'] = $TargetUser['morale_droptime'];
-                        $_FleetCache['MoraleCache'][$TargetUser['id']]['lastupdate'] = $TargetUser['morale_lastupdate'];
-
-                        $ReportData['morale'][$TargetUser['id']] = array
-                        (
-                            'usertype' => 'def',
-                            'type' => MORALE_POSITIVE,
-                            'factor' => $Morale_Factor,
-                            'level' => $TargetUser['morale_level']
-                        );
-                    }
-                }
-            }
+            $reportMoraleEntries = $moraleUpdate['reportMoraleEntries'];
         }
 
         // CREATE BATTLE REPORT
@@ -889,6 +831,10 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
         $ReportData['init']['onMoon'] = true;
         $ReportData['init']['atk_lost'] = $RealDebrisMetalAtk + $RealDebrisCrystalAtk + $RealDebrisDeuteriumAtk;
         $ReportData['init']['def_lost'] = $RealDebrisMetalDef + $RealDebrisCrystalDef + $RealDebrisDeuteriumDef;
+
+        if (!empty($reportMoraleEntries)) {
+            $ReportData['morale'] = $reportMoraleEntries;
+        }
 
         foreach($RoundsData as $RoundKey => $RoundData)
         {

--- a/includes/functions/MissionCaseDestruction.php
+++ b/includes/functions/MissionCaseDestruction.php
@@ -108,14 +108,13 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
         }
 
         // MoraleSystem Init
-        if(MORALE_ENABLED)
-        {
-            if(!empty($_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]))
-            {
-                $FleetRow['morale_level'] = $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['level'];
-                $FleetRow['morale_droptime'] = $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['droptime'];
-                $FleetRow['morale_lastupdate'] = $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['lastupdate'];
-            }
+        if (MORALE_ENABLED) {
+            Flights\Utils\FleetCache\loadMoraleDataFromCache([
+                'destination' => &$FleetRow,
+                'fleetCache' => &$_FleetCache,
+                'userID' => $FleetRow['fleet_owner'],
+            ]);
+
             Morale_ReCalculate($FleetRow, $FleetRow['fleet_start_time']);
             $AttackersData[0]['morale'] = $FleetRow['morale_level'];
             $AttackersData[0]['moralePoints'] = $FleetRow['morale_points'];
@@ -129,14 +128,13 @@ function MissionCaseDestruction($FleetRow, &$_FleetCache)
                 $moraleCombatModifiers
             );
 
-            if(!$IsAbandoned)
-            {
-                if(!empty($_FleetCache['MoraleCache'][$TargetUser['id']]))
-                {
-                    $TargetUser['morale_level'] = $_FleetCache['MoraleCache'][$TargetUser['id']]['level'];
-                    $TargetUser['morale_droptime'] = $_FleetCache['MoraleCache'][$TargetUser['id']]['droptime'];
-                    $TargetUser['morale_lastupdate'] = $_FleetCache['MoraleCache'][$TargetUser['id']]['lastupdate'];
-                }
+            if (!$IsAbandoned) {
+                Flights\Utils\FleetCache\loadMoraleDataFromCache([
+                    'destination' => &$TargetUser,
+                    'fleetCache' => &$_FleetCache,
+                    'userID' => $TargetUser['id'],
+                ]);
+
                 Morale_ReCalculate($TargetUser, $FleetRow['fleet_start_time']);
                 $DefendersData[0]['morale'] = $TargetUser['morale_level'];
                 $DefendersData[0]['moralePoints'] = $TargetUser['morale_points'];

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -168,16 +168,14 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 }
                 $AttackingFleetOwners[$FleetData['fleet_id']] = $FleetData['fleet_owner'];
 
-                if(MORALE_ENABLED)
-                {
-                    if(empty($_TempCache['MoraleCache'][$FleetData['fleet_owner']]))
-                    {
-                        if(!empty($_FleetCache['MoraleCache'][$FleetData['fleet_owner']]))
-                        {
-                            $FleetData['morale_level'] = $_FleetCache['MoraleCache'][$FleetData['fleet_owner']]['level'];
-                            $FleetData['morale_droptime'] = $_FleetCache['MoraleCache'][$FleetData['fleet_owner']]['droptime'];
-                            $FleetData['morale_lastupdate'] = $_FleetCache['MoraleCache'][$FleetData['fleet_owner']]['lastupdate'];
-                        }
+                if (MORALE_ENABLED) {
+                    if (empty($_TempCache['MoraleCache'][$FleetData['fleet_owner']])) {
+                        Flights\Utils\FleetCache\loadMoraleDataFromCache([
+                            'destination' => &$FleetData,
+                            'fleetCache' => &$_FleetCache,
+                            'userID' => $FleetData['fleet_owner'],
+                        ]);
+
                         Morale_ReCalculate($FleetData, $FleetRow['fleet_start_time']);
                         $AttackersData[$i]['morale'] = $FleetData['morale_level'];
                         $AttackersData[$i]['moralePoints'] = $FleetData['morale_points'];
@@ -217,14 +215,13 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
         }
 
         // MoraleSystem Init
-        if(MORALE_ENABLED)
-        {
-            if(!empty($_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]))
-            {
-                $FleetRow['morale_level'] = $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['level'];
-                $FleetRow['morale_droptime'] = $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['droptime'];
-                $FleetRow['morale_lastupdate'] = $_FleetCache['MoraleCache'][$FleetRow['fleet_owner']]['lastupdate'];
-            }
+        if (MORALE_ENABLED) {
+            Flights\Utils\FleetCache\loadMoraleDataFromCache([
+                'destination' => &$FleetRow,
+                'fleetCache' => &$_FleetCache,
+                'userID' => $FleetRow['fleet_owner'],
+            ]);
+
             Morale_ReCalculate($FleetRow, $FleetRow['fleet_start_time']);
             $AttackersData[0]['morale'] = $FleetRow['morale_level'];
             $AttackersData[0]['moralePoints'] = $FleetRow['morale_points'];
@@ -249,14 +246,13 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                 $moraleCombatModifiers
             );
 
-            if(!$IsAbandoned)
-            {
-                if(!empty($_FleetCache['MoraleCache'][$TargetUser['id']]))
-                {
-                    $TargetUser['morale_level'] = $_FleetCache['MoraleCache'][$TargetUser['id']]['level'];
-                    $TargetUser['morale_droptime'] = $_FleetCache['MoraleCache'][$TargetUser['id']]['droptime'];
-                    $TargetUser['morale_lastupdate'] = $_FleetCache['MoraleCache'][$TargetUser['id']]['lastupdate'];
-                }
+            if (!$IsAbandoned) {
+                Flights\Utils\FleetCache\loadMoraleDataFromCache([
+                    'destination' => &$TargetUser,
+                    'fleetCache' => &$_FleetCache,
+                    'userID' => $TargetUser['id'],
+                ]);
+
                 Morale_ReCalculate($TargetUser, $FleetRow['fleet_start_time']);
                 $DefendersData[0]['morale'] = $TargetUser['morale_level'];
                 $DefendersData[0]['moralePoints'] = $TargetUser['morale_points'];

--- a/includes/functions/MissionCaseGroupAttack.php
+++ b/includes/functions/MissionCaseGroupAttack.php
@@ -916,9 +916,11 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                     continue;
                 }
 
-                $_FleetCache['MoraleCache'][$userID]['level'] = $moraleRawData['morale_level'];
-                $_FleetCache['MoraleCache'][$userID]['droptime'] = $moraleRawData['morale_droptime'];
-                $_FleetCache['MoraleCache'][$userID]['lastupdate'] = $moraleRawData['morale_lastupdate'];
+                Flights\Utils\FleetCache\updateMoraleDataCache([
+                    'fleetCache' => &$_FleetCache,
+                    'userID' => $userID,
+                    'userMoraleData' => $moraleRawData,
+                ]);
 
                 $ReportData['morale'][$userID] = [
                     'usertype' => 'atk',
@@ -965,9 +967,11 @@ function MissionCaseGroupAttack($FleetRow, &$_FleetCache)
                     continue;
                 }
 
-                $_FleetCache['MoraleCache'][$userID]['level'] = $moraleRawData['morale_level'];
-                $_FleetCache['MoraleCache'][$userID]['droptime'] = $moraleRawData['morale_droptime'];
-                $_FleetCache['MoraleCache'][$userID]['lastupdate'] = $moraleRawData['morale_lastupdate'];
+                Flights\Utils\FleetCache\updateMoraleDataCache([
+                    'fleetCache' => &$_FleetCache,
+                    'userID' => $userID,
+                    'userMoraleData' => $moraleRawData,
+                ]);
 
                 $ReportData['morale'][$userID] = [
                     'usertype' => 'def',

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -12,6 +12,7 @@ call_user_func(function () {
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');
     include($includePath . './utils/calculations/calculateUnitsRebuild.utils.php');
     include($includePath . './utils/factories/createCombatMessages.utils.php');
+    include($includePath . './utils/factories/createCombatReportMoraleEntry.utils.php');
     include($includePath . './utils/factories/createFleetDevelopmentLogEntries.utils.php');
     include($includePath . './utils/factories/createFleetUpdateEntry.utils.php');
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -7,6 +7,7 @@ call_user_func(function () {
     $includePath = $_EnginePath . 'modules/flights/';
 
     include($includePath . './utils/calculations/calculatePostCombatMorale.utils.php');
+    include($includePath . './utils/calculations/calculatePostCombatMoraleUpdates.utils.php');
     include($includePath . './utils/calculations/calculatePillageFactor.utils.php');
     include($includePath . './utils/calculations/calculatePillageStorage.utils.php');
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -15,6 +15,7 @@ call_user_func(function () {
     include($includePath . './utils/factories/createFleetDevelopmentLogEntries.utils.php');
     include($includePath . './utils/factories/createFleetUpdateEntry.utils.php');
     include($includePath . './utils/fleetCache/updateGalaxyDebris.utils.php');
+    include($includePath . './utils/fleetCache/morale.utils.php');
     include($includePath . './utils/fleetCache/updateUserStats.utils.php');
     include($includePath . './utils/helpers/hasLostAnyDefenseSystem.utils.php');
     include($includePath . './utils/initializers/defenderDetails.utils.php');

--- a/modules/flights/_includes.php
+++ b/modules/flights/_includes.php
@@ -6,6 +6,7 @@ call_user_func(function () {
 
     $includePath = $_EnginePath . 'modules/flights/';
 
+    include($includePath . './utils/calculations/calculatePostCombatMorale.utils.php');
     include($includePath . './utils/calculations/calculatePillageFactor.utils.php');
     include($includePath . './utils/calculations/calculatePillageStorage.utils.php');
     include($includePath . './utils/calculations/calculateResourcesLoss.utils.php');

--- a/modules/flights/utils/calculations/calculatePostCombatMorale.utils.php
+++ b/modules/flights/utils/calculations/calculatePostCombatMorale.utils.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Calculations;
+
+use UniEngine\Engine\Includes\Helpers\Common\Collections;
+
+/**
+ * @param array $params
+ * @param array $params['attackersMorale']
+ * @param array $params['defendersMorale']
+ */
+function calculateCombatAttackersMoraleDetails($params) {
+    $attackersMorale = $params['attackersMorale'];
+    $defendersMorale = $params['defendersMorale'];
+
+    $totalAttackersMoralePoints = 0;
+    $totalDefendersMoralePoints = 0;
+
+    foreach ($attackersMorale as $userMoraleData) {
+        $totalAttackersMoralePoints += $userMoraleData['morale_points'];
+    }
+    foreach ($defendersMorale as $userMoraleData) {
+        $totalDefendersMoralePoints += $userMoraleData['morale_points'];
+    }
+
+    $totalAttackersMoraleFactor = (
+        $totalAttackersMoralePoints /
+        $totalDefendersMoralePoints
+    );
+    $isAttackersUnionSignificantlyStronger = ($totalAttackersMoraleFactor > MORALE_MINIMALFACTOR);
+
+    $attackersMoraleFactorGetter = (
+        $isAttackersUnionSignificantlyStronger ?
+            function ($userMoraleData) use ($totalAttackersMoraleFactor) {
+                return [
+                    'factor' => $totalAttackersMoraleFactor,
+                    'isAttackerStronger' => true,
+                ];
+            } :
+            function ($userMoraleData) use ($totalDefendersMoralePoints) {
+                $factor = ($userMoraleData['morale_points'] / $totalDefendersMoralePoints);
+                $isUserStronger = ($factor >= 1);
+
+                $normalizedFactor = (
+                    $factor >= 1 ?
+                    $factor :
+                    pow($factor, -1)
+                );
+
+                return [
+                    'factor' => $normalizedFactor,
+                    'isAttackerStronger' => $isUserStronger,
+                ];
+            }
+    );
+
+    return [
+        'attackersFactors' => array_map(
+            $attackersMoraleFactorGetter,
+            $attackersMorale
+        ),
+        'isAttackersUnionSignificantlyStronger' => $isAttackersUnionSignificantlyStronger,
+    ];
+}
+
+/**
+ * @param array $params
+ * @param enum $params['combatResult']
+ * @param array $params['attackersFactors']
+ * @param boolean $params['isAttackersUnionSignificantlyStronger']
+ */
+function calculateCombatDefendersMoraleDetails($params) {
+    return [
+        'totalDefendersMoraleFactor' => _calculateTotalDefendersMoraleFactor($params),
+    ];
+}
+
+/**
+ * @see $params - calculateCombatAttackersMoraleDetails($params)
+ */
+function _calculateTotalDefendersMoraleFactor($params) {
+    if ($params['combatResult'] === COMBAT_ATK) {
+        return 0;
+    }
+
+    if ($params['isAttackersUnionSignificantlyStronger']) {
+        return Collections\firstN($params['attackersFactors'], 1)[0]['factor'];
+    }
+
+    return array_reduce(
+        $params['attackersFactors'],
+        function ($accumulator, $factorObject) {
+            if (
+                !$factorObject['isAttackerStronger'] ||
+                $factorObject['factor'] <= MORALE_MINIMALFACTOR
+            ) {
+                return $accumulator;
+            }
+
+            return $accumulator + $factorObject['factor'];
+        },
+        0
+    );
+}
+
+?>

--- a/modules/flights/utils/calculations/calculatePostCombatMoraleUpdates.utils.php
+++ b/modules/flights/utils/calculations/calculatePostCombatMoraleUpdates.utils.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Calculations;
+
+use UniEngine\Engine\Modules\Flights;
+
+/**
+ * @param array $params
+ * @param enum $params['combatResult']
+ * @param array $params['fleetRow']
+ * @param array $params['attackersMorale']
+ * @param array $params['defendersMorale']
+ * @param ref $params['fleetCache']
+ */
+function calculatePostCombatMoraleUpdates($params) {
+    $combatResult = $params['combatResult'];
+    $fleetRow = $params['fleetRow'];
+    $attackersMorale = $params['attackersMorale'];
+    $defendersMorale = $params['defendersMorale'];
+    $fleetCache = &$params['fleetCache'];
+
+    $combatAttackersMoraleDetails = Flights\Utils\Calculations\calculateCombatAttackersMoraleDetails([
+        'attackersMorale' => $attackersMorale,
+        'defendersMorale' => $defendersMorale,
+    ]);
+
+    $reportMoraleEntries = [];
+
+    foreach ($attackersMorale as $userID => $moraleRawData) {
+        $moraleDetails = $combatAttackersMoraleDetails['attackersFactors'][$userID];
+        $moraleFactor = $moraleDetails['factor'];
+
+        if ($moraleFactor <= MORALE_MINIMALFACTOR) {
+            continue;
+        }
+
+        $moraleUpdateType = (
+            $moraleDetails['isAttackerStronger'] ?
+                MORALE_NEGATIVE :
+                MORALE_POSITIVE
+        );
+
+        $hasUpdatedMoraleData = Morale_AddMorale(
+            $moraleRawData,
+            $moraleUpdateType,
+            $moraleFactor,
+            1,
+            1,
+            $fleetRow['fleet_start_time']
+        );
+
+        if (!$hasUpdatedMoraleData) {
+            continue;
+        }
+
+        Flights\Utils\FleetCache\updateMoraleDataCache([
+            'fleetCache' => &$fleetCache,
+            'userID' => $userID,
+            'userMoraleData' => $moraleRawData,
+        ]);
+        $reportMoraleEntries[$userID] = Flights\Utils\Factories\createCombatReportMoraleEntry([
+            'userType' => Flights\Utils\Factories\MoraleEntryUserType::Attacker,
+            'updateType' => $moraleUpdateType,
+            'combatMoraleFactor' => $moraleFactor,
+            'newMoraleLevel' => $moraleRawData['morale_level'],
+        ]);
+    }
+
+    $combatDefendersMoraleDetails = Flights\Utils\Calculations\calculateCombatDefendersMoraleDetails([
+        'combatResult' => $combatResult,
+        'attackersFactors' => $combatAttackersMoraleDetails['attackersFactors'],
+        'isAttackersUnionSignificantlyStronger' => $combatAttackersMoraleDetails['isAttackersUnionSignificantlyStronger'],
+    ]);
+    $totalDefendersMoraleFactor = $combatDefendersMoraleDetails['totalDefendersMoraleFactor'];
+
+    foreach ($defendersMorale as $userID => $moraleRawData) {
+        if ($totalDefendersMoraleFactor <= 0) {
+            continue;
+        }
+
+        $moraleLevelMultiplier = (
+            $combatResult === COMBAT_DRAW ?
+                1 / 2 :
+                1
+        );
+        $moraleTimeMultiplier = (
+            $combatResult === COMBAT_DRAW ?
+                1 / 2 :
+                1
+        );
+        $moraleUpdateType = MORALE_POSITIVE;
+
+        $hasUpdatedMoraleData = Morale_AddMorale(
+            $moraleRawData,
+            $moraleUpdateType,
+            $totalDefendersMoraleFactor,
+            $moraleLevelMultiplier,
+            $moraleTimeMultiplier,
+            $fleetRow['fleet_start_time']
+        );
+
+        if (!$hasUpdatedMoraleData) {
+            continue;
+        }
+
+        Flights\Utils\FleetCache\updateMoraleDataCache([
+            'fleetCache' => &$fleetCache,
+            'userID' => $userID,
+            'userMoraleData' => $moraleRawData,
+        ]);
+        $reportMoraleEntries[$userID] = Flights\Utils\Factories\createCombatReportMoraleEntry([
+            'userType' => Flights\Utils\Factories\MoraleEntryUserType::Defender,
+            'updateType' => $moraleUpdateType,
+            'combatMoraleFactor' => $totalDefendersMoraleFactor,
+            'newMoraleLevel' => $moraleRawData['morale_level'],
+        ]);
+    }
+
+    return [
+        'reportMoraleEntries' => $reportMoraleEntries,
+    ];
+}
+
+?>

--- a/modules/flights/utils/factories/createCombatReportMoraleEntry.utils.php
+++ b/modules/flights/utils/factories/createCombatReportMoraleEntry.utils.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\Factories;
+
+abstract class MoraleEntryUserType {
+    const Attacker = 'atk';
+    const Defender = 'def';
+}
+
+/**
+ * @param array $params
+ * @param enum $params['userType']
+ * @param enum $params['updateType']
+ * @param number $params['combatMoraleFactor']
+ * @param number $params['newMoraleLevel']
+ */
+function createCombatReportMoraleEntry($params) {
+    return [
+        'usertype' => $params['userType'],
+        'type' => $params['updateType'],
+        'factor' => $params['combatMoraleFactor'],
+        'level' => $params['newMoraleLevel']
+    ];
+}
+
+?>

--- a/modules/flights/utils/fleetCache/morale.utils.php
+++ b/modules/flights/utils/fleetCache/morale.utils.php
@@ -6,6 +6,17 @@ namespace UniEngine\Engine\Modules\Flights\Utils\FleetCache;
  * @param array $params
  * @param ref $params['fleetCache']
  * @param array $params['userID']
+ */
+function hasCachedMoraleData($params) {
+    $userID = $params['userID'];
+
+    return !empty($params['fleetCache']['MoraleCache'][$userID]);
+}
+
+/**
+ * @param array $params
+ * @param ref $params['fleetCache']
+ * @param array $params['userID']
  * @param array $params['userMoraleData']
  */
 function updateMoraleDataCache($params) {
@@ -18,6 +29,26 @@ function updateMoraleDataCache($params) {
         'droptime' => $userMoraleData['morale_droptime'],
         'lastupdate' => $userMoraleData['morale_lastupdate'],
     ];
+}
+
+/**
+ * @param array $params
+ * @param ref $params['destination']
+ * @param ref $params['fleetCache']
+ * @param array $params['userID']
+ */
+function loadMoraleDataFromCache($params) {
+    $destination = &$params['destination'];
+    $userID = $params['userID'];
+    $cacheEntry = $params['fleetCache']['MoraleCache'][$userID];
+
+    if (!hasCachedMoraleData($params)) {
+        return;
+    }
+
+    $destination['morale_level'] = $cacheEntry['level'];
+    $destination['morale_droptime'] = $cacheEntry['droptime'];
+    $destination['morale_lastupdate'] = $cacheEntry['lastupdate'];
 }
 
 ?>

--- a/modules/flights/utils/fleetCache/morale.utils.php
+++ b/modules/flights/utils/fleetCache/morale.utils.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Flights\Utils\FleetCache;
+
+/**
+ * @param array $params
+ * @param ref $params['fleetCache']
+ * @param array $params['userID']
+ * @param array $params['userMoraleData']
+ */
+function updateMoraleDataCache($params) {
+    $fleetCache = &$params['fleetCache'];
+    $userID = $params['userID'];
+    $userMoraleData = $params['userMoraleData'];
+
+    $fleetCache['MoraleCache'][$userID] = [
+        'level' => $userMoraleData['morale_level'],
+        'droptime' => $userMoraleData['morale_droptime'],
+        'lastupdate' => $userMoraleData['morale_lastupdate'],
+    ];
+}
+
+?>


### PR DESCRIPTION
## Summary:

All three possible combat missions (MissionAttack, MissionDestruction & MissionGroupAttack) share almost the same mechanism of combat morale updating. This mechanism should be implemented in just one place and shared among them.

## Changelog:

- [x] Export combat morale updating into a separate function
    - [x] Function export (as utility)
    - [x] Use in Regular attack
    - [x] Use in Group attack (ACS)
    - [x] Use in Moon destruction
- [x] Fix United Attacks morale updater, where in cases of significant "stronger" attackers group, the defender would get a morale boost even when the attackers won the battle (defenders should get a boost only when they won or they drawn the battle)
- [x] Unify loading data from morale cache into a variable


## Related issues or PRs:

- #91 
