### PR TITLE
GH-112 | Fix tasks data handling upon completion

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1289,13 +1289,13 @@ function Handler_UserTasksUpdate()
             // Protection against multiplied Tasks and Buggy-Unlock
             if(!empty($UserParsedTasks['locked']))
             {
-                foreach($UserParsedTasks['locked'] as $CatID => $_Vars_TasksData)
+                foreach($UserParsedTasks['locked'] as $CatID => $lockedTaskIDs)
                 {
                     if(strstr($CatID, 's'))
                     {
                         $CatID = str_replace('s', '', $CatID);
                     }
-                    foreach($_Vars_TasksData as $TaskID)
+                    foreach($lockedTaskIDs as $TaskID)
                     {
                         if(!empty($UserParsedTasks[$CatID]))
                         {


### PR DESCRIPTION
Relates to #112 

Fixes the issue with tasks completion when we're updating more than one player's task data at a time.

Changelog:
- [x] Do not accidentally overwrite `$_Vars_TasksData` variable when iterating over locked tasks array