### PR TITLE
Refactor messages sending form

### DIFF
--- a/messages.php
+++ b/messages.php
@@ -72,11 +72,13 @@ switch($_GET['mode'])
         $MsgBox = [];
 
         if (isset($_POST['send_msg'])) {
-            $handleSendMessage = function () use ($_User, $_Lang, $_EnginePath, &$parse, &$MsgBox) {
+            $handleSendMessage = function () use ($_User, $_Lang, $_EnginePath, &$parse, &$MsgBox, $_MaxLength_Subject, $_MaxLength_Text) {
                 $formDataNormalizationResult = Messages\Utils\normalizeFormData(
                     $_POST,
                     [
                         'senderUser' => &$_User,
+                        'subjectMaxLength' => $_MaxLength_Subject,
+                        'contentMaxLength' => $_MaxLength_Text,
                     ]
                 );
 

--- a/messages.php
+++ b/messages.php
@@ -109,6 +109,17 @@ switch($_GET['mode'])
                     $formData['message']['subject']
             );
 
+            if (
+                $formData['replyToId'] !== null &&
+                (
+                    $result['isSuccess'] ||
+                    !$errors['isReplyToInvalid']
+                )
+            ) {
+                $parse['FormInsert_LockUsername'] = 'disabled';
+                $parse['FormInsert_LockSubject'] = 'disabled';
+            }
+
             if (!$result['isSuccess']) {
                 $errors = $result['errors'];
 

--- a/messages.php
+++ b/messages.php
@@ -222,7 +222,6 @@ switch($_GET['mode'])
             $isReplying = !empty($_GET['replyto']);
 
             if ($isReplying) {
-                // TODO: Reuse similar code from normalizeFormData
                 $handleReplyTo = function () use ($_Lang, $_User, &$parse, &$MsgBox) {
                     $replyId = round($_GET['replyto']);
 

--- a/messages.php
+++ b/messages.php
@@ -101,7 +101,10 @@ switch($_GET['mode'])
                     ''
             );
             $parse['FormInsert_subject'] = (
-                $formData['meta']['nextSubject'] !== null ?
+                (
+                    $formData['meta']['nextSubject'] !== null &&
+                    $result['isSuccess']
+                ) ?
                     $formData['meta']['nextSubject'] :
                     $formData['message']['subject']
             );

--- a/messages.php
+++ b/messages.php
@@ -307,28 +307,21 @@ switch($_GET['mode'])
                 }
             }
 
-            if($AllowSend === true)
-            {
-                $FormSend['type'] = $FormData['type'];
-                $FormSend['subject'] = $FormData['subject'];
-                $FormSend['text'] = $FormData['text'];
-                $FormSend['uid'] = $FormData['uid'];
-                $FormSend['Thread_ID'] = $FormData['replyto'];
-                $FormSend['Thread_IsLast'] = ($FormSend['Thread_ID'] > 0 ? 1 : 0);
-
-                if($FormSend['Thread_ID'] > 0)
-                {
-                    if($FormData['Thread_Started'] === false)
-                    {
-                        doquery("UPDATE {{table}} SET `Thread_ID` = `id`, `Thread_IsLast` = 1 WHERE `id` = {$FormSend['Thread_ID']} LIMIT 1;", 'messages');
-                    }
-                    else
-                    {
-                        doquery("UPDATE {{table}} SET `Thread_IsLast` = 0 WHERE `Thread_ID` = {$FormSend['Thread_ID']} AND `id_owner` = {$FormSend['uid']};", 'messages');
-                    }
-                }
-
-                Cache_Message($FormSend['uid'], $_User['id'], $Now, $FormSend['type'], '', $FormSend['subject'], $FormSend['text'], $FormSend['Thread_ID'], $FormSend['Thread_IsLast']);
+            if ($AllowSend === true) {
+                Messages\Utils\sendMessage([
+                    'senderUser' => &$_User,
+                    'recipientUser' => [
+                        'id' => $FormData['uid'],
+                    ],
+                    'messageData' => [
+                        'timestamp' => $Now,
+                        'type' => $FormData['type'],
+                        'subject' => $FormData['subject'],
+                        'content' => $FormData['text'],
+                        'threadId' => $FormData['replyto'],
+                        'threadHasStarted' => $FormData['Thread_Started'],
+                    ],
+                ]);
 
                 if(preg_match('#'.$_Lang['mess_answer_prefix'].'\[([0-9]{1,})\]\: #si', $FormData['subject'], $ThisMatch))
                 {

--- a/modules/messages/_includes.php
+++ b/modules/messages/_includes.php
@@ -12,6 +12,7 @@ call_user_func(function () {
     include($includePath . './input/batchActions.userCommands.php');
     include($includePath . './utils/batchDeleteMessages.utils.php');
     include($includePath . './utils/batchMessageUpdates.utils.php');
+    include($includePath . './utils/sendMessage.utils.php');
     include($includePath . './validators/validateWithIgnoreSystem.validators.php');
 
 });

--- a/modules/messages/_includes.php
+++ b/modules/messages/_includes.php
@@ -12,6 +12,9 @@ call_user_func(function () {
     include($includePath . './input/batchActions.userCommands.php');
     include($includePath . './utils/batchDeleteMessages.utils.php');
     include($includePath . './utils/batchMessageUpdates.utils.php');
+    include($includePath . './utils/createReplyMessageSubject.utils.php');
+    include($includePath . './utils/fetchFormDataForReply.utils.php');
+    include($includePath . './utils/getMessageCopyId.utils.php');
     include($includePath . './utils/sendMessage.utils.php');
     include($includePath . './validators/validateWithIgnoreSystem.validators.php');
 

--- a/modules/messages/_includes.php
+++ b/modules/messages/_includes.php
@@ -14,6 +14,8 @@ call_user_func(function () {
     include($includePath . './utils/batchMessageUpdates.utils.php');
     include($includePath . './utils/createReplyMessageSubject.utils.php');
     include($includePath . './utils/fetchFormDataForReply.utils.php');
+    include($includePath . './utils/fetchRecipientDataByUserId.utils.php');
+    include($includePath . './utils/fetchRecipientDataByUsername.utils.php');
     include($includePath . './utils/getMessageCopyId.utils.php');
     include($includePath . './utils/sendMessage.utils.php');
     include($includePath . './validators/validateWithIgnoreSystem.validators.php');

--- a/modules/messages/_includes.php
+++ b/modules/messages/_includes.php
@@ -12,6 +12,7 @@ call_user_func(function () {
     include($includePath . './input/batchActions.userCommands.php');
     include($includePath . './utils/batchDeleteMessages.utils.php');
     include($includePath . './utils/batchMessageUpdates.utils.php');
+    include($includePath . './validators/validateWithIgnoreSystem.validators.php');
 
 });
 

--- a/modules/messages/_includes.php
+++ b/modules/messages/_includes.php
@@ -10,6 +10,7 @@ call_user_func(function () {
     include($includePath . './commands/batchDeleteMessagesOlderThan.commands.php');
     include($includePath . './commands/batchMarkMessagesAsRead.commands.php');
     include($includePath . './input/batchActions.userCommands.php');
+    include($includePath . './input/sendMessage.userCommands.php');
     include($includePath . './utils/batchDeleteMessages.utils.php');
     include($includePath . './utils/batchMessageUpdates.utils.php');
     include($includePath . './utils/createReplyMessageSubject.utils.php');

--- a/modules/messages/_includes.php
+++ b/modules/messages/_includes.php
@@ -17,6 +17,7 @@ call_user_func(function () {
     include($includePath . './utils/fetchRecipientDataByUserId.utils.php');
     include($includePath . './utils/fetchRecipientDataByUsername.utils.php');
     include($includePath . './utils/getMessageCopyId.utils.php');
+    include($includePath . './utils/normalizeFormData.utils.php');
     include($includePath . './utils/sendMessage.utils.php');
     include($includePath . './validators/validateWithIgnoreSystem.validators.php');
 

--- a/modules/messages/input/sendMessage.userCommands.php
+++ b/modules/messages/input/sendMessage.userCommands.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Messages\Input\UserCommands;
+
+use UniEngine\Engine\Modules\Messages;
+
+/**
+ * @param array $input
+ *  Same as Messages\Utils\normalizeFormData
+ *
+ * @param array $params
+ * @param objectRef $params['senderUser']
+ * @param number $params['subjectMaxLength']
+ * @param number $params['contentMaxLength']
+ * @param number $params['timestamp']
+ */
+function handleSendMessage(&$input, $params) {
+    global $_EnginePath;
+
+    $createSuccess = function ($messages, $payload) {
+        return [
+            'isSuccess' => true,
+            'messages' => $messages,
+            'payload' => $payload,
+        ];
+    };
+    $createFailure = function ($errors, $payload) {
+        return [
+            'isSuccess' => false,
+            'errors' => $errors,
+            'payload' => $payload,
+        ];
+    };
+
+    $senderUser = &$params['senderUser'];
+    $subjectMaxLength = $params['subjectMaxLength'];
+    $contentMaxLength = $params['contentMaxLength'];
+    $timestamp = $params['timestamp'];
+
+    $formDataNormalizationResult = Messages\Utils\normalizeFormData(
+        $input,
+        [
+            'senderUser' => &$senderUser,
+            'subjectMaxLength' => $subjectMaxLength,
+            'contentMaxLength' => $contentMaxLength,
+        ]
+    );
+
+    $formData = $formDataNormalizationResult['formData'];
+
+    if (!$formDataNormalizationResult['isSuccess']) {
+        return $createFailure(
+            $formDataNormalizationResult['errors'],
+            [ 'formData' => $formData, ]
+        );
+    }
+
+    // Validation
+    if ($formData['recipient']['id'] == $senderUser['id']) {
+        return $createFailure(
+            [
+                'isWritingToYourself' => true,
+            ],
+            [ 'formData' => $formData, ]
+        );
+    }
+
+    if (empty($formData['message']['subject'])) {
+        return $createFailure(
+            [
+                'isMessageSubjectEmpty' => true,
+            ],
+            [ 'formData' => $formData, ]
+        );
+    }
+    if (empty($formData['message']['content'])) {
+        return $createFailure(
+            [
+                'isMessageContentEmpty' => true,
+            ],
+            [ 'formData' => $formData, ]
+        );
+    }
+
+    include($_EnginePath . 'includes/functions/FilterMessages.php');
+
+    if (FilterMessages($formData['message']['content'], 1)) {
+        return $createFailure(
+            [
+                'isMessageContentSpam' => true,
+            ],
+            [ 'formData' => $formData, ]
+        );
+    }
+
+    $ignoreSystemValidationResult = Messages\Validators\validateWithIgnoreSystem([
+        'senderUser' => &$senderUser,
+        'recipientUser' => $formData['recipient'],
+    ]);
+
+    if (!$ignoreSystemValidationResult['isValid']) {
+        return $createFailure(
+            $ignoreSystemValidationResult['errors'],
+            [ 'formData' => $formData, ]
+        );
+    }
+
+    Messages\Utils\sendMessage([
+        'senderUser' => &$senderUser,
+        'recipientUser' => $formData['recipient'],
+        'messageData' => [
+            'timestamp' => $timestamp,
+            'type' => $formData['message']['type'],
+            'subject' => $formData['message']['subject'],
+            'content' => $formData['message']['content'],
+            'threadId' => $formData['replyToId'],
+            'threadHasStarted' => $formData['meta']['isReplyingToOngoingThread'],
+        ],
+    ]);
+
+    return $createSuccess(
+        [],
+        [ 'formData' => $formData, ]
+    );
+}
+
+?>

--- a/modules/messages/utils/createReplyMessageSubject.utils.php
+++ b/modules/messages/utils/createReplyMessageSubject.utils.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Messages\Utils;
+
+/**
+ * Creates new subject by increasing reply counter on the previous subject.
+ *
+ * @param array $params
+ * @param string $params['previousSubject']
+ * @param number $params['replyCounter']
+ */
+function createReplyMessageSubject($params) {
+    global $_Lang;
+
+    $previousSubject = $params['previousSubject'];
+    $replyCounter = $params['replyCounter'];
+
+    $cleanSubject = preg_replace(
+        '#' . $_Lang['mess_answer_prefix'] . '\[[0-9]{1,}\]\: #si',
+        '',
+        $previousSubject
+    );
+    $newReplySubject = "{$_Lang['mess_answer_prefix']} [{$replyCounter}]: {$cleanSubject}";
+
+    return $newReplySubject;
+}
+
+?>

--- a/modules/messages/utils/fetchFormDataForReply.utils.php
+++ b/modules/messages/utils/fetchFormDataForReply.utils.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Messages\Utils;
+
+use UniEngine\Engine\Modules\Messages;
+
+/**
+ * Fetches necessary data when trying to reply to an existing message.
+ *
+ * @param array $params
+ * @param number $params['replyToMessageId']
+ * @param &array $params['senderUser']
+ */
+function fetchFormDataForReply($params) {
+    $senderUser = &$params['senderUser'];
+    $replyToMessageId = $params['replyToMessageId'];
+
+    $senderUserId = $senderUser['id'];
+
+    $query_GetReferencedMessage = (
+        "SELECT " .
+        "`m`.`id`, `m`.`Thread_ID`, `m`.`subject`, `m`.`text`, `u`.`id` AS `user_id`, `u`.`username`, `u`.`authlevel` " .
+        "FROM " .
+        "{{table}} AS `m` " .
+        "LEFT JOIN " .
+        "`{{prefix}}users` AS `u` ON `u`.`id` = IF(`m`.`id_owner` != {$senderUserId}, `m`.`id_owner`, `m`.`id_sender`) " .
+        "WHERE " .
+        "( " .
+        "`m`.`id` = {$replyToMessageId} OR " .
+        "`m`.`Thread_ID` = {$replyToMessageId} " .
+        ") AND ( " .
+        "`m`.`id_owner` = {$senderUserId} OR " .
+        "`m`.`id_sender` = {$senderUserId} " .
+        ") AND " .
+        "`deleted` = false " .
+        "LIMIT 1 " .
+        ";"
+    );
+
+    $referencedMessage = doquery($query_GetReferencedMessage, 'messages', true);
+
+    if (!$referencedMessage || $referencedMessage['id'] <= 0) {
+        return [
+            'isSuccess' => false,
+            'error' => [
+                'messageNotFound' => true,
+            ],
+        ];
+    }
+
+
+    $isInOngoingThread = ($referencedMessage['Thread_ID'] > 0);
+    $previousSubject = $referencedMessage['subject'];
+    $replyCounter = 1;
+
+    $formData = [
+        'username' => $referencedMessage['username'],
+        'uid' => $referencedMessage['user_id'],
+        'authlevel' => $referencedMessage['authlevel'],
+        'subject' => null,
+        'replyto' => $replyToMessageId,
+        'Thread_Started' => $isInOngoingThread,
+        'lock_username' => true,
+        'lock_subject' => true,
+    ];
+
+    $checkIsMessageCopy = Messages\Utils\getMessageCopyId([
+        'messageData' => &$referencedMessage,
+    ]);
+
+    if ($checkIsMessageCopy['isSuccess']) {
+        $query_GetOriginalMessage = (
+            "SELECT `subject` " .
+            "FROM {{table}} " .
+            "WHERE `id` = {$checkIsMessageCopy['payload']['originalMessageId']} " .
+            "LIMIT 1 " .
+            ";"
+        );
+
+        $originalMessage = doquery($query_GetOriginalMessage, 'messages', true);
+
+        $previousSubject = $originalMessage['subject'];
+    }
+
+    if ($isInOngoingThread) {
+        $query_GetThreadLength = (
+            "SELECT " .
+            "COUNT(*) AS `Count` " .
+            "FROM {{table}} " .
+            "WHERE " .
+            "`Thread_ID` = {$replyToMessageId} " .
+            ";"
+        );
+
+        $result_GetThreadLength = doquery($query_GetThreadLength, 'messages', true);
+
+        $replyCounter = $result_GetThreadLength['Count'];
+    }
+
+    $formData['subject'] = Messages\Utils\createReplyMessageSubject([
+        'previousSubject' => $previousSubject,
+        'replyCounter' => $replyCounter,
+    ]);
+
+    return [
+        'isSuccess' => true,
+        'payload' => $formData,
+    ];
+}
+
+?>

--- a/modules/messages/utils/fetchFormDataForReply.utils.php
+++ b/modules/messages/utils/fetchFormDataForReply.utils.php
@@ -58,6 +58,7 @@ function fetchFormDataForReply($params) {
         'uid' => $referencedMessage['user_id'],
         'authlevel' => $referencedMessage['authlevel'],
         'subject' => null,
+        'nextSubject' => null,
         'replyto' => $replyToMessageId,
         'Thread_Started' => $isInOngoingThread,
         'lock_username' => true,
@@ -100,6 +101,10 @@ function fetchFormDataForReply($params) {
     $formData['subject'] = Messages\Utils\createReplyMessageSubject([
         'previousSubject' => $previousSubject,
         'replyCounter' => $replyCounter,
+    ]);
+    $formData['nextSubject'] = Messages\Utils\createReplyMessageSubject([
+        'previousSubject' => $previousSubject,
+        'replyCounter' => ($replyCounter + 1),
     ]);
 
     return [

--- a/modules/messages/utils/fetchRecipientDataByUserId.utils.php
+++ b/modules/messages/utils/fetchRecipientDataByUserId.utils.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Messages\Utils;
+
+/**
+ * Fetches necessary data of a message recipient.
+ *
+ * @param array $params
+ * @param string $params['userId']
+ */
+function fetchRecipientDataByUserId($params) {
+    $userId = intval($params['userId']);
+
+    if (!($userId > 0)) {
+        return [
+            'isSuccess' => false,
+            'errors' => [
+                'isUserIdInvalid' => true,
+            ],
+        ];
+    }
+
+    $query_fetchRecipientData = (
+        "SELECT `id`, `username`, `authlevel` " .
+        "FROM {{table}} " .
+        "WHERE `id` = '{$userId}' " .
+        "LIMIT 1 " .
+        ";"
+    );
+    $result_fetchRecipientData = doquery($query_fetchRecipientData, 'users', true);
+
+    if (!$result_fetchRecipientData) {
+        return [
+            'isSuccess' => false,
+            'errors' => [
+                'notFound' => true,
+            ],
+        ];
+
+        return;
+    }
+
+    $recipientData = [
+        'id' => $result_fetchRecipientData['id'],
+        'username' => $result_fetchRecipientData['username'],
+        'authlevel' => $result_fetchRecipientData['authlevel'],
+    ];
+
+    return [
+        'isSuccess' => true,
+        'payload' => $recipientData,
+    ];
+}
+
+?>

--- a/modules/messages/utils/fetchRecipientDataByUserId.utils.php
+++ b/modules/messages/utils/fetchRecipientDataByUserId.utils.php
@@ -36,8 +36,6 @@ function fetchRecipientDataByUserId($params) {
                 'notFound' => true,
             ],
         ];
-
-        return;
     }
 
     $recipientData = [

--- a/modules/messages/utils/fetchRecipientDataByUsername.utils.php
+++ b/modules/messages/utils/fetchRecipientDataByUsername.utils.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Messages\Utils;
+
+/**
+ * Fetches necessary data of a message recipient.
+ *
+ * @param array $params
+ * @param string $params['username']
+ */
+function fetchRecipientDataByUsername($params) {
+    $username = trim($params['username']);
+
+    if (!preg_match(REGEXP_USERNAME_ABSOLUTE, $username)) {
+        return [
+            'isSuccess' => false,
+            'errors' => [
+                'isUsernameInvalid' => true,
+            ],
+        ];
+    }
+
+    $query_fetchRecipientData = (
+        "SELECT `id`, `authlevel` " .
+        "FROM {{table}} " .
+        "WHERE `username` = '{$username}' " .
+        "LIMIT 1 " .
+        ";"
+    );
+    $result_fetchRecipientData = doquery($query_fetchRecipientData, 'users', true);
+
+    if (!$result_fetchRecipientData) {
+        return [
+            'isSuccess' => false,
+            'errors' => [
+                'notFound' => true,
+            ],
+        ];
+
+        return;
+    }
+
+    $recipientData = [
+        'id' => $result_fetchRecipientData['id'],
+        'username' => $username,
+        'authlevel' => $result_fetchRecipientData['authlevel'],
+    ];
+
+    return [
+        'isSuccess' => true,
+        'payload' => $recipientData,
+    ];
+}
+
+?>

--- a/modules/messages/utils/getMessageCopyId.utils.php
+++ b/modules/messages/utils/getMessageCopyId.utils.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Messages\Utils;
+
+/**
+ * Extracts message's carbon copy reference ID, as long as the message is indeed
+ * a copy of another message. Otherwise, returns an error.
+ *
+ * @param array $params
+ * @param &array $params['messageData']
+ * @param string $params['messageData']['text']
+ */
+function getMessageCopyId($params) {
+    $messageContent = $params['messageData']['text'];
+
+    $extractedMatches = null;
+
+    $isCopy = preg_match('/^\{COPY\_MSG\_\#([0-9]{1,}){1}\}$/D', $messageContent, $extractedMatches);
+
+    if ($isCopy !== 1) {
+        return [
+            'isSuccess' => false,
+            'error' => [
+                'isNotCopy' => true,
+            ],
+        ];
+    }
+
+    return [
+        'isSuccess' => true,
+        'payload' => [
+            'originalMessageId' => $extractedMatches[1],
+        ],
+    ];
+}
+
+?>

--- a/modules/messages/utils/normalizeFormData.utils.php
+++ b/modules/messages/utils/normalizeFormData.utils.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Messages\Utils;
+
+use UniEngine\Engine\Modules\Messages;
+
+/**
+ * Send a message by inserting it into the Messages Cache system's queue.
+ *
+ * @param &array $input
+ * @param number | null $input['replyto']
+ * @param string $input['uname']
+ * @param 'on' | null $input['send_as_admin_msg']
+ * @param string $input['subject']
+ * @param string $input['text']
+ * @param array $params
+ * @param &array $params['senderUser']
+ */
+function normalizeFormData($input, $params) {
+    $senderUser = &$params['senderUser'];
+
+    $formData = [
+        'replyToId' => null,
+        'recipient' => [
+            'id' => null,
+            'username' => null,
+            'authlevel' => null,
+        ],
+        'message' => [
+            'type' => null,
+            'subject' => null,
+            'content' => null,
+        ],
+        'meta' => [
+            'isSendingAsAdmin' => false,
+            'isReplyingToOngoingThread' => false,
+            'nextSubject' => null,
+        ],
+    ];
+
+    $normalizationErrors = [
+        'isReplyToInvalid' => false,
+        'isRecipientUsernameInvalid' => false,
+        'recipientNotFound' => false,
+        'hasNoPermissionToChangeType' => false,
+    ];
+
+    $isReplying = !empty($input['replyto']);
+
+    if ($isReplying) {
+        $handleReplyTo = function () use ($input, $senderUser, &$formData, &$normalizationErrors) {
+            $replyId = round($input['replyto']);
+
+            if (!($replyId > 0)) {
+                $normalizationErrors['isReplyToInvalid'] = true;
+
+                return;
+            }
+
+            $replyFormData = Messages\Utils\fetchFormDataForReply([
+                'replyToMessageId' => $replyId,
+                'senderUser' => &$senderUser,
+            ]);
+
+            if (!$replyFormData['isSuccess']) {
+                $normalizationErrors['isReplyToInvalid'] = true;
+
+                return;
+            }
+
+            $formData['replyToId'] = $replyId;
+            $formData['recipient'] = [
+                'id' => $replyFormData['payload']['uid'],
+                'username' => $replyFormData['payload']['username'],
+                'authlevel' => $replyFormData['payload']['authlevel'],
+            ];
+            $formData['message']['subject'] = $replyFormData['payload']['subject'];
+            $formData['meta']['isReplyingToOngoingThread'] = $replyFormData['payload']['Thread_Started'];
+            $formData['meta']['nextSubject'] = $replyFormData['payload']['nextSubject'];
+        };
+
+        $handleReplyTo();
+    }
+
+    if (!$isReplying) {
+        $fetchResult = (
+            !empty($input['uid']) ?
+                Messages\Utils\fetchRecipientDataByUserId([
+                    'userId' => $input['uid'],
+                ]) :
+                Messages\Utils\fetchRecipientDataByUsername([
+                    'username' => $input['uname'],
+                ])
+        );
+
+        if (!$fetchResult['isSuccess']) {
+            if ($fetchResult['errors']['isUsernameInvalid']) {
+                $normalizationErrors['isRecipientUsernameInvalid'] = true;
+            }
+            if ($fetchResult['errors']['notFound']) {
+                $normalizationErrors['recipientNotFound'] = true;
+            }
+        }
+
+        if ($fetchResult['isSuccess']) {
+            $recipientData = $fetchResult['payload'];
+
+            $formData['recipient'] = [
+                'id' => $recipientData['id'],
+                'username' => $recipientData['username'],
+                'authlevel' => $recipientData['authlevel'],
+            ];
+        }
+    }
+
+    $handleMessageType = function () use ($input, $senderUser, &$formData, &$normalizationErrors) {
+        if (
+            empty($input['send_as_admin_msg']) ||
+            $input['send_as_admin_msg'] !== 'on'
+        ) {
+            $formData['message']['type'] = 1;
+
+            return;
+        }
+
+        if (!CheckAuth('supportadmin', AUTHCHECK_NORMAL, $senderUser)) {
+            $normalizationErrors['hasNoPermissionToChangeType'] = true;
+
+            return;
+        }
+
+        $formData['message']['type'] = 80;
+        $formData['meta']['isSendingAsAdmin'] = true;
+    };
+
+    $normalizeUserContent = function ($content, $params) {
+        $normalizedContent = (
+            isset($content) ?
+                stripslashes(trim($content)) :
+                ''
+        );
+
+        if (get_magic_quotes_gpc()) {
+            $normalizedContent = stripslashes($normalizedContent);
+        }
+
+        $normalizedContent = strip_tags($normalizedContent);
+        $normalizedContent = substr($normalizedContent, 0, $params['maxLength']);
+
+        return $normalizedContent;
+    };
+
+    $handleMessageType();
+
+    if (empty($formData['message']['subject'])) {
+        $formData['message']['subject'] = $normalizeUserContent(
+            $input['subject'],
+            [ 'maxLength' => 100, ]
+        );
+    }
+
+    $formData['message']['content'] = $normalizeUserContent(
+        $input['text'],
+        [ 'maxLength' => 5000, ]
+    );
+
+    $hasNormalizationErrors = (
+        count(
+            array_filter(
+                $normalizationErrors,
+                function ($hasErrorOccured) {
+                    return $hasErrorOccured;
+                }
+            )
+        ) > 0
+    );
+
+    return [
+        'isSuccess' => !$hasNormalizationErrors,
+        'formData' => $formData,
+        'errors' => $normalizationErrors,
+    ];
+}
+
+?>

--- a/modules/messages/utils/normalizeFormData.utils.php
+++ b/modules/messages/utils/normalizeFormData.utils.php
@@ -15,6 +15,8 @@ use UniEngine\Engine\Modules\Messages;
  * @param string $input['text']
  * @param array $params
  * @param &array $params['senderUser']
+ * @param number $params['subjectMaxLength']
+ * @param number $params['contentMaxLength']
  */
 function normalizeFormData($input, $params) {
     $senderUser = &$params['senderUser'];
@@ -155,13 +157,13 @@ function normalizeFormData($input, $params) {
     if (empty($formData['message']['subject'])) {
         $formData['message']['subject'] = $normalizeUserContent(
             $input['subject'],
-            [ 'maxLength' => 100, ]
+            [ 'maxLength' => $params['subjectMaxLength'], ]
         );
     }
 
     $formData['message']['content'] = $normalizeUserContent(
         $input['text'],
-        [ 'maxLength' => 5000, ]
+        [ 'maxLength' => $params['contentMaxLength'], ]
     );
 
     $hasNormalizationErrors = (

--- a/modules/messages/utils/sendMessage.utils.php
+++ b/modules/messages/utils/sendMessage.utils.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Messages\Utils;
+
+/**
+ * Send a message by inserting it into the Messages Cache system's queue.
+ *
+ * @param array $params
+ * @param &array $params['senderUser']
+ * @param &array $params['recipientUser']
+ * @param array $params['messageData']
+ * @param string $params['messageData']['timestamp']
+ * @param string $params['messageData']['type']
+ * @param string $params['messageData']['subject']
+ * @param string $params['messageData']['content']
+ * @param string $params['messageData']['threadId']
+ * @param string $params['messageData']['threadHasStarted']
+ */
+function sendMessage($params) {
+    $senderUser = &$params['senderUser'];
+    $recipientUser = &$params['recipientUser'];
+
+    $messageData = $params['messageData'];
+    $isInThread = ($messageData['threadId'] > 0);
+    $isThisMessageNewLastMessageInThread = $isInThread;
+
+    if ($isInThread) {
+        if ($messageData['threadHasStarted']) {
+            $query_UpdateExistingThread = (
+                "UPDATE {{table}} " .
+                "SET " .
+                "`Thread_IsLast` = 0 " .
+                "WHERE " .
+                "`Thread_ID` = {$messageData['threadId']} AND " .
+                "`id_owner` = {$recipientUser['id']} " .
+                ";"
+            );
+
+            doquery($query_UpdateExistingThread, 'messages');
+        } else {
+            $query_UpdateNewThreadFirstMessage = (
+                "UPDATE {{table}} " .
+                "SET " .
+                "`Thread_ID` = `id`, " .
+                "`Thread_IsLast` = 1 " .
+                "WHERE " .
+                "`id` = {$messageData['threadId']} " .
+                "LIMIT 1 " .
+                ";"
+            );
+
+            doquery($query_UpdateNewThreadFirstMessage, 'messages');
+        }
+    }
+
+    Cache_Message(
+        $recipientUser['id'],
+        $senderUser['id'],
+        $messageData['timestamp'],
+        $messageData['type'],
+        '',
+        $messageData['subject'],
+        $messageData['content'],
+        $messageData['threadId'],
+        $isThisMessageNewLastMessageInThread
+    );
+
+    return [
+        'isSuccess' => true,
+    ];
+}
+
+?>

--- a/modules/messages/validators/index.php
+++ b/modules/messages/validators/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/messages/validators/validateWithIgnoreSystem.validators.php
+++ b/modules/messages/validators/validateWithIgnoreSystem.validators.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Messages\Validators;
+
+/**
+ * @param array $params
+ * @param &array $params['senderUser']
+ * @param &array $params['recipientUser']
+ */
+function validateWithIgnoreSystem($params) {
+    $isValid = function () {
+        return [
+            'isValid' => true,
+        ];
+    };
+    $isInvalid = function ($errors) {
+        return [
+            'isValid' => false,
+            'errors' => $errors,
+        ];
+    };
+
+    $senderUser = &$params['senderUser'];
+    $recipientUser = &$params['recipientUser'];
+
+    if (
+        CheckAuth('user', AUTHCHECK_HIGHER, $senderUser) ||
+        CheckAuth('user', AUTHCHECK_HIGHER, $recipientUser)
+    ) {
+        return $isValid();
+    }
+
+    $Query_IgnoreSystem = '';
+    $Query_IgnoreSystem .= "SELECT `OwnerID` FROM {{table}} WHERE ";
+    $Query_IgnoreSystem .= "(`OwnerID` = {$senderUser['id']} AND `IgnoredID` = {$recipientUser['id']}) OR ";
+    $Query_IgnoreSystem .= "(`OwnerID` = {$recipientUser['id']} AND `IgnoredID` = {$senderUser['id']}) ";
+    $Query_IgnoreSystem .= "LIMIT 2; -- messages.php|IgnoreSystem";
+
+    $Result_IgnoreSystem = doquery($Query_IgnoreSystem, 'ignoresystem');
+
+    if ($Result_IgnoreSystem->num_rows == 0) {
+        return $isValid();
+    }
+
+    $validationErrors = [
+        'isRecipientIgnored' => false,
+        'isSenderIgnored' => false,
+    ];
+
+    while ($IgnoreData = $Result_IgnoreSystem->fetch_assoc()) {
+        if ($IgnoreData['OwnerID'] == $senderUser['id']) {
+            $validationErrors['isRecipientIgnored'] = true;
+        }
+        if ($IgnoreData['OwnerID'] == $recipientUser['id']) {
+            $validationErrors['isSenderIgnored'] = true;
+        }
+    }
+
+    return $isInvalid($validationErrors);
+}
+
+?>


### PR DESCRIPTION
## Summary:

`messages.php` is a huge file that needs to be split into smaller chunks to make it more manageable and flexible.

## Changelog:

- [x] Split messages sending code into separate, purpose-built functions
- [x] Move general handler out of `messages.php` to a separate handler function

## Is migration required?

### NO

## Related issues or PRs:

- #126 