### PR TITLE
Refactor Battle Engine (part 3)

### DIFF
--- a/includes/CombatEngineAres.php
+++ b/includes/CombatEngineAres.php
@@ -337,10 +337,12 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
 
                 $LeftForce = $AvailableForce - $Force2TDShield;
 
-                $Able2Destroy = (
+                $targetRemainingCount = (
                     $DefShipsTypesCount[$TShip][$TUser] -
                     (isset($AlreadyDestroyedDef[$TKey]) ? $AlreadyDestroyedDef[$TKey] : 0)
                 );
+
+                $Able2Destroy = $targetRemainingCount;
 
                 if ($ACount < $Able2Destroy) {
                     $Able2Destroy = $ACount;
@@ -404,8 +406,8 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                 $ForceContribution['atk'][$AUser] += $UsedForce;
                 $ShotDown['atk']['d'][$AUser][$TShip] += $Destroyed;
                 $ShotDown['def']['l'][$TUser][$TShip] += $Destroyed;
-                if($Destroyed == ($DefShipsTypesCount[$TShip][$TUser] - (isset($AlreadyDestroyedDef[$TKey]) ? $AlreadyDestroyedDef[$TKey] : 0)))
-                {
+
+                if ($Destroyed == $targetRemainingCount) {
                     unset($DefShipsForce_Copy[$TKey]);
                     if(isset($DefHullDmg[$TKey]))
                     {
@@ -413,9 +415,7 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     }
                     unset($DefShipsTypesOwners[$TShip][$TUser]);
                     $DefShipsTypes[$TShip] -= 1;
-                }
-                else
-                {
+                } else {
                     if($Destroyed > 0)
                     {
                         if(!isset($AlreadyDestroyedDef[$TKey]))
@@ -607,10 +607,12 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
 
                     $LeftForce = $AvailableForce - $Force2TDShield;
 
-                    $Able2Destroy = (
+                    $targetRemainingCount = (
                         $DefShipsTypesCount[$TShip][$TUser] -
                         (isset($AlreadyDestroyedDef[$TKey]) ? $AlreadyDestroyedDef[$TKey] : 0)
                     );
+
+                    $Able2Destroy = $targetRemainingCount;
 
                     if ($ACount < $Able2Destroy) {
                         $Able2Destroy = $ACount;
@@ -674,8 +676,8 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     $ForceContribution['atk'][$AUser] += $UsedForce;
                     $ShotDown['atk']['d'][$AUser][$TShip] += $Destroyed;
                     $ShotDown['def']['l'][$TUser][$TShip] += $Destroyed;
-                    if($Destroyed == ($DefShipsTypesCount[$TShip][$TUser] - (isset($AlreadyDestroyedDef[$TKey]) ? $AlreadyDestroyedDef[$TKey] : 0)))
-                    {
+
+                    if ($Destroyed == $targetRemainingCount) {
                         unset($DefShipsForce_Copy[$TKey]);
                         if(isset($DefHullDmg[$TKey]))
                         {
@@ -683,9 +685,7 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                         }
                         unset($DefShipsTypesOwners[$TShip][$TUser]);
                         $DefShipsTypes[$TShip] -= 1;
-                    }
-                    else
-                    {
+                    } else {
                         if($Destroyed > 0)
                         {
                             if(!isset($AlreadyDestroyedDef[$TKey]))
@@ -810,10 +810,12 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
 
                 $LeftForce = $AvailableForce - $Force2TDShield;
 
-                $Able2Destroy = (
+                $targetRemainingCount = (
                     $AtkShipsTypesCount[$TShip][$TUser] -
                     (isset($AlreadyDestroyedAtk[$TKey]) ? $AlreadyDestroyedAtk[$TKey] : 0)
                 );
+
+                $Able2Destroy = $targetRemainingCount;
 
                 if ($ACount < $Able2Destroy) {
                     $Able2Destroy = $ACount;
@@ -877,8 +879,8 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                 $ForceContribution['def'][$AUser] += $UsedForce;
                 $ShotDown['def']['d'][$AUser][$TShip] += $Destroyed;
                 $ShotDown['atk']['l'][$TUser][$TShip] += $Destroyed;
-                if($Destroyed == ($AtkShipsTypesCount[$TShip][$TUser] - (isset($AlreadyDestroyedAtk[$TKey]) ? $AlreadyDestroyedAtk[$TKey] : 0)))
-                {
+
+                if ($Destroyed == $targetRemainingCount) {
                     unset($AtkShipsForce_Copy[$TKey]);
                     if(isset($AtkHullDmg[$TKey]))
                     {
@@ -886,9 +888,7 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     }
                     unset($AtkShipsTypesOwners[$TShip][$TUser]);
                     $AtkShipsTypes[$TShip] -= 1;
-                }
-                else
-                {
+                } else {
                     if($Destroyed > 0)
                     {
                         if(!isset($AlreadyDestroyedAtk[$TKey]))
@@ -1080,10 +1080,12 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
 
                     $LeftForce = $AvailableForce - $Force2TDShield;
 
-                    $Able2Destroy = (
+                    $targetRemainingCount = (
                         $AtkShipsTypesCount[$TShip][$TUser] -
                         (isset($AlreadyDestroyedAtk[$TKey]) ? $AlreadyDestroyedAtk[$TKey] : 0)
                     );
+
+                    $Able2Destroy = $targetRemainingCount;
 
                     if ($ACount < $Able2Destroy) {
                         $Able2Destroy = $ACount;
@@ -1147,8 +1149,8 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     $ForceContribution['def'][$AUser] += $UsedForce;
                     $ShotDown['def']['d'][$AUser][$TShip] += $Destroyed;
                     $ShotDown['atk']['l'][$TUser][$TShip] += $Destroyed;
-                    if($Destroyed == ($AtkShipsTypesCount[$TShip][$TUser] - (isset($AlreadyDestroyedAtk[$TKey]) ? $AlreadyDestroyedAtk[$TKey] : 0)))
-                    {
+
+                    if ($Destroyed == $targetRemainingCount) {
                         unset($AtkShipsForce_Copy[$TKey]);
                         if(isset($AtkHullDmg[$TKey]))
                         {
@@ -1156,9 +1158,7 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                         }
                         unset($AtkShipsTypesOwners[$TShip][$TUser]);
                         $AtkShipsTypes[$TShip] -= 1;
-                    }
-                    else
-                    {
+                    } else {
                         if($Destroyed > 0)
                         {
                             if(!isset($AlreadyDestroyedAtk[$TKey]))

--- a/includes/CombatEngineAres.php
+++ b/includes/CombatEngineAres.php
@@ -454,7 +454,6 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                 $TotalForceNeed = 0;
                 $TotalShootsNeed = 0;
                 $GainedShoots = 0;
-                $RapidForce4Shield = false;
                 $RapidForce4Hull = false;
                 $RapidForceMinShoots = false;
 
@@ -476,7 +475,6 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                         'roundShieldStateCacheByTargetKey' => $DefShields,
                     ])['forceNeeded'];
 
-                    $RapidForce4Shield[$Owner] = $Force2TDShield;
                     $RapidForce4Hull[$Owner] = $CalcCount * $DefShipsHull[$ThisKey];
                     if(isset($DefHullDmg[$ThisKey]))
                     {
@@ -484,7 +482,7 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     }
                     $RapidForceMinShoots[$Owner] = $CalcCount;
 
-                    $TotalForceNeed += ($RapidForce4Shield[$Owner] + $RapidForce4Hull[$Owner]);
+                    $TotalForceNeed += ($Force2TDShield + $RapidForce4Hull[$Owner]);
                     $TotalShootsNeed += $RapidForceMinShoots[$Owner];
                 }
 
@@ -928,7 +926,6 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                 $TotalForceNeed = 0;
                 $TotalShootsNeed = 0;
                 $GainedShoots = 0;
-                $RapidForce4Shield = false;
                 $RapidForce4Hull = false;
                 $RapidForceMinShoots = false;
 
@@ -950,7 +947,6 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                         'roundShieldStateCacheByTargetKey' => $AtkShields,
                     ])['forceNeeded'];
 
-                    $RapidForce4Shield[$Owner] = $Force2TDShield;
                     $RapidForce4Hull[$Owner] = $CalcCount * $AtkShipsHull[$ThisKey];
                     if(isset($AtkHullDmg[$ThisKey]))
                     {
@@ -958,7 +954,7 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     }
                     $RapidForceMinShoots[$Owner] = $CalcCount;
 
-                    $TotalForceNeed += ($RapidForce4Shield[$Owner] + $RapidForce4Hull[$Owner]);
+                    $TotalForceNeed += ($Force2TDShield + $RapidForce4Hull[$Owner]);
                     $TotalShootsNeed += $RapidForceMinShoots[$Owner];
                 }
 

--- a/includes/CombatEngineAres.php
+++ b/includes/CombatEngineAres.php
@@ -1147,7 +1147,7 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     $ForceContribution['def'][$AUser] += $UsedForce;
                     $ShotDown['def']['d'][$AUser][$TShip] += $Destroyed;
                     $ShotDown['atk']['l'][$TUser][$TShip] += $Destroyed;
-                    if($Destroyed == ($AtkShipsTypesCount[$TShip][$TUser] - (isset($AlreadyDestroyedAtk[$TKey]) ? $AlreadyDestroyedAtk[$ThisKey] : 0)))
+                    if($Destroyed == ($AtkShipsTypesCount[$TShip][$TUser] - (isset($AlreadyDestroyedAtk[$TKey]) ? $AlreadyDestroyedAtk[$TKey] : 0)))
                     {
                         unset($AtkShipsForce_Copy[$TKey]);
                         if(isset($AtkHullDmg[$TKey]))

--- a/includes/CombatEngineAres.php
+++ b/includes/CombatEngineAres.php
@@ -303,23 +303,18 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                 }
 
                 $AvailableForce = $AForce * $ACount;
-                $Force2TDShield = 0;
 
-                $isShotBypassingShield = Ares\Evaluators\isShotBypassingShield([
+                $shieldsTakeDownStats = Ares\Calculations\calculateShieldsTakeDownStats([
                     'shotForce' => $AForce,
+                    'targetUserId' => $TUser,
+                    'targetShipId' => $TShip,
                     'targetShipShield' => $DefShipsShield[$TKey],
+                    'targetShipCount' => $DefShipsTypesCount[$TShip][$TUser],
+                    'roundShieldStateCacheByTargetKey' => $DefShields,
                 ]);
 
-                if (!$isShotBypassingShield) {
-                    if (
-                        isset($DefShields[$TKey]['left']) &&
-                        $DefShields[$TKey]['left'] === true
-                    ) {
-                        $Force2TDShield = $DefShields[$TKey]['shield'];
-                    } else {
-                        $Force2TDShield = $DefShipsShield[$TKey] * $DefShipsTypesCount[$TShip][$TUser];
-                    }
-                }
+                $Force2TDShield = $shieldsTakeDownStats['forceNeeded'];
+                $isShotBypassingShield = $shieldsTakeDownStats['isShotBypassingShield'];
 
                 if ($AvailableForce <= $Force2TDShield) {
                     $Rounds[$i]['atk']['force'] += $AvailableForce;
@@ -575,23 +570,18 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     }
 
                     $AvailableForce = $AForce * $ACount;
-                    $Force2TDShield = 0;
 
-                    $isShotBypassingShield = Ares\Evaluators\isShotBypassingShield([
+                    $shieldsTakeDownStats = Ares\Calculations\calculateShieldsTakeDownStats([
                         'shotForce' => $AForce,
+                        'targetUserId' => $TUser,
+                        'targetShipId' => $TShip,
                         'targetShipShield' => $DefShipsShield[$TKey],
+                        'targetShipCount' => $DefShipsTypesCount[$TShip][$TUser],
+                        'roundShieldStateCacheByTargetKey' => $DefShields,
                     ]);
 
-                    if (!$isShotBypassingShield) {
-                        if (
-                            isset($DefShields[$TKey]['left']) &&
-                            $DefShields[$TKey]['left'] === true
-                        ) {
-                            $Force2TDShield = $DefShields[$TKey]['shield'];
-                        } else {
-                            $Force2TDShield = $DefShipsShield[$TKey] * $DefShipsTypesCount[$TShip][$TUser];
-                        }
-                    }
+                    $Force2TDShield = $shieldsTakeDownStats['forceNeeded'];
+                    $isShotBypassingShield = $shieldsTakeDownStats['isShotBypassingShield'];
 
                     if ($AvailableForce <= $Force2TDShield) {
                         $Rounds[$i]['atk']['force'] += $AvailableForce;
@@ -777,23 +767,18 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                 }
 
                 $AvailableForce = $AForce * $ACount;
-                $Force2TDShield = 0;
 
-                $isShotBypassingShield = Ares\Evaluators\isShotBypassingShield([
+                $shieldsTakeDownStats = Ares\Calculations\calculateShieldsTakeDownStats([
                     'shotForce' => $AForce,
+                    'targetUserId' => $TUser,
+                    'targetShipId' => $TShip,
                     'targetShipShield' => $AtkShipsShield[$TKey],
+                    'targetShipCount' => $AtkShipsTypesCount[$TShip][$TUser],
+                    'roundShieldStateCacheByTargetKey' => $AtkShields,
                 ]);
 
-                if (!$isShotBypassingShield) {
-                    if (
-                        isset($AtkShields[$TKey]['left']) &&
-                        $AtkShields[$TKey]['left'] === true
-                    ) {
-                        $Force2TDShield = $AtkShields[$TKey]['shield'];
-                    } else {
-                        $Force2TDShield = $AtkShipsShield[$TKey] * $AtkShipsTypesCount[$TShip][$TUser];
-                    }
-                }
+                $Force2TDShield = $shieldsTakeDownStats['forceNeeded'];
+                $isShotBypassingShield = $shieldsTakeDownStats['isShotBypassingShield'];
 
                 if ($AvailableForce <= $Force2TDShield) {
                     $Rounds[$i]['def']['force'] += $AvailableForce;
@@ -1049,23 +1034,18 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     }
 
                     $AvailableForce = $AForce * $ACount;
-                    $Force2TDShield = 0;
 
-                    $isShotBypassingShield = Ares\Evaluators\isShotBypassingShield([
+                    $shieldsTakeDownStats = Ares\Calculations\calculateShieldsTakeDownStats([
                         'shotForce' => $AForce,
+                        'targetUserId' => $TUser,
+                        'targetShipId' => $TShip,
                         'targetShipShield' => $AtkShipsShield[$TKey],
+                        'targetShipCount' => $AtkShipsTypesCount[$TShip][$TUser],
+                        'roundShieldStateCacheByTargetKey' => $AtkShields,
                     ]);
 
-                    if (!$isShotBypassingShield) {
-                        if (
-                            isset($AtkShields[$TKey]['left']) &&
-                            $AtkShields[$TKey]['left'] === true
-                        ) {
-                            $Force2TDShield = $AtkShields[$TKey]['shield'];
-                        } else {
-                            $Force2TDShield = $AtkShipsShield[$TKey] * $AtkShipsTypesCount[$TShip][$TUser];
-                        }
-                    }
+                    $Force2TDShield = $shieldsTakeDownStats['forceNeeded'];
+                    $isShotBypassingShield = $shieldsTakeDownStats['isShotBypassingShield'];
 
                     if ($AvailableForce <= $Force2TDShield) {
                         $Rounds[$i]['def']['force'] += $AvailableForce;

--- a/includes/CombatEngineAres.php
+++ b/includes/CombatEngineAres.php
@@ -320,14 +320,20 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     $Rounds[$i]['atk']['force'] += $AvailableForce;
                     $Rounds[$i]['atk']['count'] += $ACount;
                     $Rounds[$i]['def']['shield'] += $AvailableForce;
-                    $DefShields[$TKey] = array('left' => true, 'shield' => $Force2TDShield - $AvailableForce);
+                    $DefShields[$TKey] = [
+                        'left' => true,
+                        'shield' => ($Force2TDShield - $AvailableForce),
+                    ];
                     $ACount_Copy -= $ACount;
 
                     continue;
                 }
 
                 if (!$isShotBypassingShield) {
-                    $DefShields[$TKey] = array('left' => true, 'shield' => 0);
+                    $DefShields[$TKey] = [
+                        'left' => true,
+                        'shield' => 0,
+                    ];
                 }
 
                 $LeftForce = $AvailableForce - $Force2TDShield;
@@ -587,13 +593,19 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                         $Rounds[$i]['atk']['force'] += $AvailableForce;
                         $Rounds[$i]['atk']['count'] += $ACount;
                         $Rounds[$i]['def']['shield'] += $AvailableForce;
-                        $DefShields[$TKey] = array('left' => true, 'shield' => $Force2TDShield - $AvailableForce);
+                        $DefShields[$TKey] = [
+                            'left' => true,
+                            'shield' => ($Force2TDShield - $AvailableForce),
+                        ];
 
                         continue;
                     }
 
                     if (!$isShotBypassingShield) {
-                        $DefShields[$TKey] = array('left' => true, 'shield' => 0);
+                        $DefShields[$TKey] = [
+                            'left' => true,
+                            'shield' => 0,
+                        ];
                     }
 
                     $LeftForce = $AvailableForce - $Force2TDShield;
@@ -784,14 +796,20 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     $Rounds[$i]['def']['force'] += $AvailableForce;
                     $Rounds[$i]['def']['count'] += $ACount;
                     $Rounds[$i]['atk']['shield'] += $AvailableForce;
-                    $AtkShields[$TKey] = array('left' => true, 'shield' => $Force2TDShield - $AvailableForce);
+                    $AtkShields[$TKey] = [
+                        'left' => true,
+                        'shield' => ($Force2TDShield - $AvailableForce),
+                    ];
                     $ACount_Copy -= $ACount;
 
                     continue;
                 }
 
                 if (!$isShotBypassingShield) {
-                    $AtkShields[$TKey] = array('left' => true, 'shield' => 0);
+                    $AtkShields[$TKey] = [
+                        'left' => true,
+                        'shield' => 0,
+                    ];
                 }
 
                 $LeftForce = $AvailableForce - $Force2TDShield;
@@ -1051,13 +1069,19 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                         $Rounds[$i]['def']['force'] += $AvailableForce;
                         $Rounds[$i]['def']['count'] += $ACount;
                         $Rounds[$i]['atk']['shield'] += $AvailableForce;
-                        $AtkShields[$TKey] = array('left' => true, 'shield' => $Force2TDShield - $AvailableForce);
+                        $AtkShields[$TKey] = [
+                            'left' => true,
+                            'shield' => ($Force2TDShield - $AvailableForce),
+                        ];
 
                         continue;
                     }
 
                     if (!$isShotBypassingShield) {
-                        $AtkShields[$TKey] = array('left' => true, 'shield' => 0);
+                        $AtkShields[$TKey] = [
+                            'left' => true,
+                            'shield' => 0,
+                        ];
                     }
 
                     $LeftForce = $AvailableForce - $Force2TDShield;

--- a/includes/CombatEngineAres.php
+++ b/includes/CombatEngineAres.php
@@ -468,14 +468,14 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     $ThisKey = "{$TShip}|{$Owner}";
                     $CalcCount = ($DefShipsTypesCount[$TShip][$Owner] - (isset($AlreadyDestroyedDef[$ThisKey]) ? $AlreadyDestroyedDef[$ThisKey] : 0));
 
-                    if(isset($DefShields[$ThisKey]['left']) && $DefShields[$ThisKey]['left'] === true)
-                    {
-                        $Force2TDShield = $DefShields[$ThisKey]['shield'];
-                    }
-                    else
-                    {
-                        $Force2TDShield = $DefShipsShield[$ThisKey] * $CalcCount;
-                    }
+                    $Force2TDShield = Ares\Calculations\calculateShieldsTakeDownStats([
+                        'shotForce' => 0,
+                        'targetFullKey' => $ThisKey,
+                        'targetShipShield' => $DefShipsShield[$ThisKey],
+                        'targetShipCount' => $CalcCount,
+                        'roundShieldStateCacheByTargetKey' => $DefShields,
+                    ])['forceNeeded'];
+
                     $RapidForce4Shield[$Owner] = $Force2TDShield;
                     $RapidForce4Hull[$Owner] = $CalcCount * $DefShipsHull[$ThisKey];
                     if(isset($DefHullDmg[$ThisKey]))
@@ -942,14 +942,14 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     $ThisKey = "{$TShip}|{$Owner}";
                     $CalcCount = ($AtkShipsTypesCount[$TShip][$Owner] - (isset($AlreadyDestroyedAtk[$ThisKey]) ? $AlreadyDestroyedAtk[$ThisKey] : 0));
 
-                    if(isset($AtkShields[$ThisKey]['left']) && $AtkShields[$ThisKey]['left'] === true)
-                    {
-                        $Force2TDShield = $AtkShields[$ThisKey]['shield'];
-                    }
-                    else
-                    {
-                        $Force2TDShield = $AtkShipsShield[$ThisKey] * $CalcCount;
-                    }
+                    $Force2TDShield = Ares\Calculations\calculateShieldsTakeDownStats([
+                        'shotForce' => 0,
+                        'targetFullKey' => $ThisKey,
+                        'targetShipShield' => $AtkShipsShield[$ThisKey],
+                        'targetShipCount' => $CalcCount,
+                        'roundShieldStateCacheByTargetKey' => $AtkShields,
+                    ])['forceNeeded'];
+
                     $RapidForce4Shield[$Owner] = $Force2TDShield;
                     $RapidForce4Hull[$Owner] = $CalcCount * $AtkShipsHull[$ThisKey];
                     if(isset($AtkHullDmg[$ThisKey]))

--- a/includes/CombatEngineAres.php
+++ b/includes/CombatEngineAres.php
@@ -306,8 +306,7 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
 
                 $shieldsTakeDownStats = Ares\Calculations\calculateShieldsTakeDownStats([
                     'shotForce' => $AForce,
-                    'targetUserId' => $TUser,
-                    'targetShipId' => $TShip,
+                    'targetFullKey' => $TKey,
                     'targetShipShield' => $DefShipsShield[$TKey],
                     'targetShipCount' => $DefShipsTypesCount[$TShip][$TUser],
                     'roundShieldStateCacheByTargetKey' => $DefShields,
@@ -579,8 +578,7 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
 
                     $shieldsTakeDownStats = Ares\Calculations\calculateShieldsTakeDownStats([
                         'shotForce' => $AForce,
-                        'targetUserId' => $TUser,
-                        'targetShipId' => $TShip,
+                        'targetFullKey' => $TKey,
                         'targetShipShield' => $DefShipsShield[$TKey],
                         'targetShipCount' => $DefShipsTypesCount[$TShip][$TUser],
                         'roundShieldStateCacheByTargetKey' => $DefShields,
@@ -782,8 +780,7 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
 
                 $shieldsTakeDownStats = Ares\Calculations\calculateShieldsTakeDownStats([
                     'shotForce' => $AForce,
-                    'targetUserId' => $TUser,
-                    'targetShipId' => $TShip,
+                    'targetFullKey' => $TKey,
                     'targetShipShield' => $AtkShipsShield[$TKey],
                     'targetShipCount' => $AtkShipsTypesCount[$TShip][$TUser],
                     'roundShieldStateCacheByTargetKey' => $AtkShields,
@@ -1055,8 +1052,7 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
 
                     $shieldsTakeDownStats = Ares\Calculations\calculateShieldsTakeDownStats([
                         'shotForce' => $AForce,
-                        'targetUserId' => $TUser,
-                        'targetShipId' => $TShip,
+                        'targetFullKey' => $TKey,
                         'targetShipShield' => $AtkShipsShield[$TKey],
                         'targetShipCount' => $AtkShipsTypesCount[$TShip][$TUser],
                         'roundShieldStateCacheByTargetKey' => $AtkShields,

--- a/includes/CombatEngineAres.php
+++ b/includes/CombatEngineAres.php
@@ -415,16 +415,14 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     }
                     unset($DefShipsTypesOwners[$TShip][$TUser]);
                     $DefShipsTypes[$TShip] -= 1;
-                } else {
-                    if($Destroyed > 0)
-                    {
-                        if(!isset($AlreadyDestroyedDef[$TKey]))
-                        {
-                            $AlreadyDestroyedDef[$TKey] = 0;
-                        }
-                        $AlreadyDestroyedDef[$TKey] += $Destroyed;
+                } else if ($Destroyed > 0) {
+                    if (!isset($AlreadyDestroyedDef[$TKey])) {
+                        $AlreadyDestroyedDef[$TKey] = 0;
                     }
+
+                    $AlreadyDestroyedDef[$TKey] += $Destroyed;
                 }
+
                 $ACount_Copy -= $Shoots;
             }
 
@@ -685,15 +683,12 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                         }
                         unset($DefShipsTypesOwners[$TShip][$TUser]);
                         $DefShipsTypes[$TShip] -= 1;
-                    } else {
-                        if($Destroyed > 0)
-                        {
-                            if(!isset($AlreadyDestroyedDef[$TKey]))
-                            {
-                                $AlreadyDestroyedDef[$TKey] = 0;
-                            }
-                            $AlreadyDestroyedDef[$TKey] += $Destroyed;
+                    } else if ($Destroyed > 0) {
+                        if (!isset($AlreadyDestroyedDef[$TKey])) {
+                            $AlreadyDestroyedDef[$TKey] = 0;
                         }
+
+                        $AlreadyDestroyedDef[$TKey] += $Destroyed;
                     }
                 }
             }
@@ -888,16 +883,14 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     }
                     unset($AtkShipsTypesOwners[$TShip][$TUser]);
                     $AtkShipsTypes[$TShip] -= 1;
-                } else {
-                    if($Destroyed > 0)
-                    {
-                        if(!isset($AlreadyDestroyedAtk[$TKey]))
-                        {
-                            $AlreadyDestroyedAtk[$TKey] = 0;
-                        }
-                        $AlreadyDestroyedAtk[$TKey] += $Destroyed;
+                } else if ($Destroyed > 0) {
+                    if (!isset($AlreadyDestroyedAtk[$TKey])) {
+                        $AlreadyDestroyedAtk[$TKey] = 0;
                     }
+
+                    $AlreadyDestroyedAtk[$TKey] += $Destroyed;
                 }
+
                 $ACount_Copy -= $Shoots;
             }
 
@@ -1158,15 +1151,12 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                         }
                         unset($AtkShipsTypesOwners[$TShip][$TUser]);
                         $AtkShipsTypes[$TShip] -= 1;
-                    } else {
-                        if($Destroyed > 0)
-                        {
-                            if(!isset($AlreadyDestroyedAtk[$TKey]))
-                            {
-                                $AlreadyDestroyedAtk[$TKey] = 0;
-                            }
-                            $AlreadyDestroyedAtk[$TKey] += $Destroyed;
+                    } else if ($Destroyed > 0) {
+                        if (!isset($AlreadyDestroyedAtk[$TKey])) {
+                            $AlreadyDestroyedAtk[$TKey] = 0;
                         }
+
+                        $AlreadyDestroyedAtk[$TKey] += $Destroyed;
                     }
                 }
             }

--- a/includes/CombatEngineAres.php
+++ b/includes/CombatEngineAres.php
@@ -454,7 +454,6 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                 $TotalForceNeed = 0;
                 $TotalShootsNeed = 0;
                 $GainedShoots = 0;
-                $RapidForceMinShoots = false;
 
                 $shotsDistribution = [
                     'calculatedForTypeId' => [],
@@ -482,10 +481,10 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     $currentTotalHull = ($CalcCount * $DefShipsHull[$ThisKey]);
                     $forceToDestroyHull = ($currentTotalHull - $currentHullDamage);
 
-                    $RapidForceMinShoots[$Owner] = $CalcCount;
+                    $minimalShotsNeeded = $CalcCount;
 
                     $TotalForceNeed += ($Force2TDShield + $forceToDestroyHull);
-                    $TotalShootsNeed += $RapidForceMinShoots[$Owner];
+                    $TotalShootsNeed += $minimalShotsNeeded;
                 }
 
                 $TotalAvailableShoots = floor(($AtkShipsTypesCount[$AShip][$AUser] * $ShipsSD['a'][$AUser][$AShip][$TShip]) * (1 - (isset($AtkDontShootRF[$AKey]) ? $AtkDontShootRF[$AKey] : 0)));
@@ -928,7 +927,6 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                 $TotalForceNeed = 0;
                 $TotalShootsNeed = 0;
                 $GainedShoots = 0;
-                $RapidForceMinShoots = false;
 
                 $shotsDistribution = [
                     'calculatedForTypeId' => [],
@@ -956,10 +954,10 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                     $currentTotalHull = ($CalcCount * $AtkShipsHull[$ThisKey]);
                     $forceToDestroyHull = ($currentTotalHull - $currentHullDamage);
 
-                    $RapidForceMinShoots[$Owner] = $CalcCount;
+                    $minimalShotsNeeded = $CalcCount;
 
                     $TotalForceNeed += ($Force2TDShield + $forceToDestroyHull);
-                    $TotalShootsNeed += $RapidForceMinShoots[$Owner];
+                    $TotalShootsNeed += $minimalShotsNeeded;
                 }
 
                 $TotalAvailableShoots = floor(($DefShipsTypesCount[$AShip][$AUser] * $ShipsSD['d'][$AUser][$AShip][$TShip]) * (1 - (isset($DefDontShootRF[$AKey]) ? $DefDontShootRF[$AKey] : 0)));

--- a/includes/CombatEngineAres.php
+++ b/includes/CombatEngineAres.php
@@ -454,7 +454,6 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                 $TotalForceNeed = 0;
                 $TotalShootsNeed = 0;
                 $GainedShoots = 0;
-                $RapidForce4Hull = false;
                 $RapidForceMinShoots = false;
 
                 $shotsDistribution = [
@@ -475,14 +474,17 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                         'roundShieldStateCacheByTargetKey' => $DefShields,
                     ])['forceNeeded'];
 
-                    $RapidForce4Hull[$Owner] = $CalcCount * $DefShipsHull[$ThisKey];
-                    if(isset($DefHullDmg[$ThisKey]))
-                    {
-                        $RapidForce4Hull[$Owner] -= $DefHullDmg[$ThisKey] * $DefShipsHull[$ThisKey];
-                    }
+                    $currentHullDamage = (
+                        isset($DefHullDmg[$ThisKey]) ?
+                            ($DefHullDmg[$ThisKey] * $DefShipsHull[$ThisKey]) :
+                            0
+                    );
+                    $currentTotalHull = ($CalcCount * $DefShipsHull[$ThisKey]);
+                    $forceToDestroyHull = ($currentTotalHull - $currentHullDamage);
+
                     $RapidForceMinShoots[$Owner] = $CalcCount;
 
-                    $TotalForceNeed += ($Force2TDShield + $RapidForce4Hull[$Owner]);
+                    $TotalForceNeed += ($Force2TDShield + $forceToDestroyHull);
                     $TotalShootsNeed += $RapidForceMinShoots[$Owner];
                 }
 
@@ -926,7 +928,6 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                 $TotalForceNeed = 0;
                 $TotalShootsNeed = 0;
                 $GainedShoots = 0;
-                $RapidForce4Hull = false;
                 $RapidForceMinShoots = false;
 
                 $shotsDistribution = [
@@ -947,14 +948,17 @@ function Combat($Attacker, $Defender, $AttackerTech, $DefenderTech, $UseRapidFir
                         'roundShieldStateCacheByTargetKey' => $AtkShields,
                     ])['forceNeeded'];
 
-                    $RapidForce4Hull[$Owner] = $CalcCount * $AtkShipsHull[$ThisKey];
-                    if(isset($AtkHullDmg[$ThisKey]))
-                    {
-                        $RapidForce4Hull[$Owner] -= $AtkHullDmg[$ThisKey] * $AtkShipsHull[$ThisKey];
-                    }
+                    $currentHullDamage = (
+                        isset($AtkHullDmg[$ThisKey]) ?
+                            ($AtkHullDmg[$ThisKey] * $AtkShipsHull[$ThisKey]) :
+                            0
+                    );
+                    $currentTotalHull = ($CalcCount * $AtkShipsHull[$ThisKey]);
+                    $forceToDestroyHull = ($currentTotalHull - $currentHullDamage);
+
                     $RapidForceMinShoots[$Owner] = $CalcCount;
 
-                    $TotalForceNeed += ($Force2TDShield + $RapidForce4Hull[$Owner]);
+                    $TotalForceNeed += ($Force2TDShield + $forceToDestroyHull);
                     $TotalShootsNeed += $RapidForceMinShoots[$Owner];
                 }
 

--- a/includes/ares/calculations.php
+++ b/includes/ares/calculations.php
@@ -2,6 +2,8 @@
 
 namespace UniEngine\Engine\Includes\Ares\Calculations;
 
+use UniEngine\Engine\Includes\Ares;
+
 function calculateShipForce($params) {
     global $_Vars_CombatUpgrades, $_Vars_CombatData;
 
@@ -60,6 +62,45 @@ function calculateShipHull($params) {
         $baseHullValuesCache[$shipId] *
         $userTechs[111]
     );
+}
+
+function calculateShieldsTakeDownStats($params) {
+    $shotForce = $params['shotForce'];
+    $targetUserId = $params['targetUserId'];
+    $targetShipId = $params['targetShipId'];
+    $targetShipShield = $params['targetShipShield'];
+    $targetShipCount = $params['targetShipCount'];
+    $roundShieldStateCache = $params['roundShieldStateCacheByTargetKey'];
+
+    $targetKey = "{$targetShipId}|{$targetUserId}";
+
+    $isShotBypassingShield = Ares\Evaluators\isShotBypassingShield([
+        'shotForce' => $shotForce,
+        'targetShipShield' => $targetShipShield,
+    ]);
+
+    if ($isShotBypassingShield) {
+        return [
+            'forceNeeded' => 0,
+            'isShotBypassingShield' => true,
+        ];
+    }
+
+    $isTargetsShieldDamaged = (
+        isset($roundShieldStateCache[$targetKey]['left']) &&
+        $roundShieldStateCache[$targetKey]['left'] === true
+    );
+
+    $forceNeeded = (
+        $isTargetsShieldDamaged ?
+            $roundShieldStateCache[$targetKey]['shield'] :
+            ($targetShipShield * $targetShipCount)
+    );
+
+    return [
+        'forceNeeded' => $forceNeeded,
+        'isShotBypassingShield' => false,
+    ];
 }
 
 ?>

--- a/includes/ares/calculations.php
+++ b/includes/ares/calculations.php
@@ -66,13 +66,10 @@ function calculateShipHull($params) {
 
 function calculateShieldsTakeDownStats($params) {
     $shotForce = $params['shotForce'];
-    $targetUserId = $params['targetUserId'];
-    $targetShipId = $params['targetShipId'];
+    $targetFullKey = $params['targetFullKey'];
     $targetShipShield = $params['targetShipShield'];
     $targetShipCount = $params['targetShipCount'];
     $roundShieldStateCache = $params['roundShieldStateCacheByTargetKey'];
-
-    $targetKey = "{$targetShipId}|{$targetUserId}";
 
     $isShotBypassingShield = Ares\Evaluators\isShotBypassingShield([
         'shotForce' => $shotForce,
@@ -87,13 +84,13 @@ function calculateShieldsTakeDownStats($params) {
     }
 
     $isTargetsShieldDamaged = (
-        isset($roundShieldStateCache[$targetKey]['left']) &&
-        $roundShieldStateCache[$targetKey]['left'] === true
+        isset($roundShieldStateCache[$targetFullKey]['left']) &&
+        $roundShieldStateCache[$targetFullKey]['left'] === true
     );
 
     $forceNeeded = (
         $isTargetsShieldDamaged ?
-            $roundShieldStateCache[$targetKey]['shield'] :
+            $roundShieldStateCache[$targetFullKey]['shield'] :
             ($targetShipShield * $targetShipCount)
     );
 


### PR DESCRIPTION
## Summary:

`CombatEngineAres.php` is a huge pile of duplicated code all over the place. It's time to extract repeated pieces into reusable functionalities to improve readability (and future modifications), reduce complexity and accidental inconsistencies between attackers' & defenders' ships behaviour.

## Changelog:

- [x] Make shield takedown calculations a shared unit of code

## Is migration required?

### NO

## Related issues or PRs:

- #131 