### PR TITLE
 Flight Control refactor (part 02) - Various refactors

### DIFF
--- a/admin/user_info.php
+++ b/admin/user_info.php
@@ -320,7 +320,11 @@ if(CheckAuth('go'))
         $Data['ally_name'] = $Data['ally_request_name'];
     }
     $Player['Ally'] = ($Data['ally_id'] > 0 ? '<a class="help" title="'.$_Lang['SearchByAlly'].'" href="userlist.php?search_user='.$Data['ally_id'].'&search_by=aid">'.$Data['ally_name'].' ('.$Data['ally_id'].')</a>'.($Data['ally_request'] != 0 ? ' ['.$_Lang['Request'].']' : ($Data['ally_owner'] == $UID ? ' ['.$_Lang['Ally_owner'].']' : '')) : '&nbsp;-&nbsp;');
-    $Player['AccountActive'] = (!empty($Data['activation_code']) ? "<b class=\"orange\">{$_Lang['_no']}</b><br/>{$_Lang['ActivationCode']}: {$Data['activation_code']}" : "<b class=\"lime\">{$_Lang['_yes']}</b>");
+    $Player['AccountActive'] = (
+        !isUserAccountActivated($Data) ?
+        "<b class=\"orange\">{$_Lang['_no']}</b><br/>{$_Lang['ActivationCode']}: {$Data['activation_code']}" :
+        "<b class=\"lime\">{$_Lang['_yes']}</b>"
+    );
     $Player['DisableIPCheck'] = (($Data['noipcheck'] == 1) ? $_Lang['_no'] : $_Lang['_yes']);
     $Player['MotherPlanet'] = "{$Data['mothername']} ({$_Lang['MotherPlanet_ID']}: {$Data['id_planet']}) [<a class=\"help\" title=\"{$_Lang['GoToGalaxy']}\" href=\"../galaxy.php?mode=3&amp;galaxy={$Data['galaxy']}&amp;system={$Data['system']}&amp;planet={$Data['planet']}\">{$Data['galaxy']}:{$Data['system']}:{$Data['planet']}</a>]";
 

--- a/admin/userlist.php
+++ b/admin/userlist.php
@@ -859,8 +859,7 @@ if(!empty($Users))
             $Bloc['UserMoreInfo'] .= "<br/><span class=\"fl\"><b class=\"red\">{$_Lang['UserIsBanned']}:</b> <b class=\"{$BanColor}\">".date('d.m.Y, H:i:s', $Data['ban_endtime'])."</b></span><span class=\"fr\">({$BanTime})</span>";
         }
         // MoreInfo - Activation Link
-        if(!empty($Data['activation_code']))
-        {
+        if (!isUserAccountActivated($Data)) {
             $Bloc['UserMoreInfo'] .= "<br/><span class=\"fl\"><b class=\"orange\">{$_Lang['UserNotActivated']}</b></span><span class=\"fr\">[{$_Lang['UserActivationLink']}: <a href=\"".(GAMEURL)."activate.php?code={$Data['activation_code']}\" target=\"_blank\">".(GAMEURL)."activate.php?code=<b class=\"orange\">{$Data['activation_code']}</b></a>]</span>";
         }
         // MoreInfo - is On Deletion

--- a/ajax/galaxyfleet.php
+++ b/ajax/galaxyfleet.php
@@ -8,6 +8,10 @@ $_EnginePath = '../';
 
 include($_EnginePath.'common.php');
 
+include($_EnginePath . 'modules/flightControl/_includes.php');
+
+use UniEngine\Engine\Modules\FlightControl;
+
 function CreateReturn($ReturnCode)
 {
     global $Update, $ShipCount, $Galaxy, $System, $Planet, $Type, $ActualFleets, $Spy_Probes, $Recyclers, $Colonizers;
@@ -431,32 +435,14 @@ if($CurrentPlanet[$_Vars_GameElements[$ShipID]] < $ShipCount)
     $ShipCount = $CurrentPlanet[$_Vars_GameElements[$ShipID]];
 }
 
-// Create SpeedsArray
-$SpeedsAvailable = array(10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
+$availableSpeeds = FlightControl\Utils\Helpers\getAvailableSpeeds([
+    'user' => &$_User,
+    'timestamp' => $Time,
+]);
 
-if($_User['admiral_time'] > $Time)
-{
-    $SpeedsAvailable[] = 12;
-    $SpeedsAvailable[] = 11;
-    $SpeedsAvailable[] = 0.5;
-    $SpeedsAvailable[] = 0.25;
-}
-if(MORALE_ENABLED)
-{
-    $MaxAvailableSpeed = max($SpeedsAvailable);
-    if($_User['morale_level'] >= MORALE_BONUS_FLEETSPEEDUP1)
-    {
-        $SpeedsAvailable[] = $MaxAvailableSpeed + (MORALE_BONUS_FLEETSPEEDUP1_VALUE / 10);
-    }
-    if($_User['morale_level'] >= MORALE_BONUS_FLEETSPEEDUP2)
-    {
-        $SpeedsAvailable[] = $MaxAvailableSpeed + (MORALE_BONUS_FLEETSPEEDUP2_VALUE / 10);
-    }
-}
-arsort($SpeedsAvailable);
-reset($SpeedsAvailable);
+reset($availableSpeeds);
 
-$GenFleetSpeed = current($SpeedsAvailable);
+$GenFleetSpeed = current($availableSpeeds);
 $SpeedFactor = getUniFleetsSpeedFactor();
 $MaxFleetSpeed = getShipsCurrentSpeed($ShipID, $_User);
 
@@ -503,7 +489,7 @@ if($CurrentPlanet['deuterium'] >= $consumption)
         // Try to SlowDown fleet only if it's Espionage Mission
         while($FleetStorage < $consumption)
         {
-            $GenFleetSpeed = next($SpeedsAvailable);
+            $GenFleetSpeed = next($availableSpeeds);
             if($GenFleetSpeed !== false)
             {
                 $duration = getFlightDuration([

--- a/ajax/galaxyfleet.php
+++ b/ajax/galaxyfleet.php
@@ -83,8 +83,12 @@ if(MORALE_ENABLED)
     Morale_ReCalculate($_User, $Time);
 }
 
-if(($_User[$_Vars_GameElements[108]] + 1 + (($_User['admiral_time'] > $Time) ? 2 : 0)) <= $ActualFleets)
-{
+$fleetSlotsCount = FlightControl\Utils\Helpers\getUserFleetSlotsCount([
+    'user' => $_User,
+    'timestamp' => $Time,
+]);
+
+if ($ActualFleets >= $fleetSlotsCount) {
     $Update = '1';
     CreateReturn('609');
 }

--- a/ajax/galaxyfleet.php
+++ b/ajax/galaxyfleet.php
@@ -481,66 +481,63 @@ $consumption = getFlightTotalConsumption(
 $fleet['start_time'] = $duration + $Time;
 $fleet['end_time'] = (2 * $duration) + $Time;
 
-if($CurrentPlanet['deuterium'] >= $consumption)
+if ($CurrentPlanet['deuterium'] < $consumption) {
+    CreateReturn('607');
+}
+
+$FleetStorage = $_Vars_Prices[$ShipID]['capacity'] * $ShipCount;
+if($Mission == 6)
 {
-    $FleetStorage = $_Vars_Prices[$ShipID]['capacity'] * $ShipCount;
-    if($Mission == 6)
+    // Try to SlowDown fleet only if it's Espionage Mission
+    while($FleetStorage < $consumption)
     {
-        // Try to SlowDown fleet only if it's Espionage Mission
-        while($FleetStorage < $consumption)
+        $GenFleetSpeed = next($availableSpeeds);
+        if($GenFleetSpeed !== false)
         {
-            $GenFleetSpeed = next($availableSpeeds);
-            if($GenFleetSpeed !== false)
-            {
-                $duration = getFlightDuration([
-                    'speedFactor' => $GenFleetSpeed,
-                    'distance' => $distance,
-                    'maxShipsSpeed' => $MaxFleetSpeed
-                ]);
-                $consumption = getFlightTotalConsumption(
-                    [
-                        'ships' => [
-                            $ShipID => $ShipCount
-                        ],
-                        'distance' => $distance,
-                        'duration' => $duration,
+            $duration = getFlightDuration([
+                'speedFactor' => $GenFleetSpeed,
+                'distance' => $distance,
+                'maxShipsSpeed' => $MaxFleetSpeed
+            ]);
+            $consumption = getFlightTotalConsumption(
+                [
+                    'ships' => [
+                        $ShipID => $ShipCount
                     ],
-                    $_User
-                );
+                    'distance' => $distance,
+                    'duration' => $duration,
+                ],
+                $_User
+            );
 
-                $fleet['start_time'] = $duration + $Time;
-                $fleet['end_time'] = (2 * $duration) + $Time;
-            }
-            else
-            {
-                break;
-            }
+            $fleet['start_time'] = $duration + $Time;
+            $fleet['end_time'] = (2 * $duration) + $Time;
         }
-    }
-
-    if($FleetStorage >= $consumption)
-    {
-        switch($Mission)
+        else
         {
-            case 6: //Spy
-                $TargetOwner = $TargetUser;
-                break;
-            case 8: //Recycling
-                $TargetOwner = 0;
-                break;
-            case 7: //Colonization
-                $TargetOwner = 0;
-                break;
+            break;
         }
     }
-    else
+}
+
+if($FleetStorage >= $consumption)
+{
+    switch($Mission)
     {
-        CreateReturn('608');
+        case 6: //Spy
+            $TargetOwner = $TargetUser;
+            break;
+        case 8: //Recycling
+            $TargetOwner = 0;
+            break;
+        case 7: //Colonization
+            $TargetOwner = 0;
+            break;
     }
 }
 else
 {
-    CreateReturn('607');
+    CreateReturn('608');
 }
 
 if(!isset($TargetID) || $TargetID <= 0)

--- a/ajax/galaxyfleet.php
+++ b/ajax/galaxyfleet.php
@@ -83,7 +83,7 @@ if(MORALE_ENABLED)
     Morale_ReCalculate($_User, $Time);
 }
 
-if(($_User[$_Vars_GameElements[108]] + 1 + (($_User['admiral_time'] > 0) ? 2 : 0)) <= $ActualFleets)
+if(($_User[$_Vars_GameElements[108]] + 1 + (($_User['admiral_time'] > $Time) ? 2 : 0)) <= $ActualFleets)
 {
     $Update = '1';
     CreateReturn('609');

--- a/ajax/galaxyfleet.php
+++ b/ajax/galaxyfleet.php
@@ -42,10 +42,11 @@ if(!isLogged())
 {
     CreateReturn('601');
 }
-if(!empty($_User['activation_code']))
-{
+
+if (!isUserAccountActivated($_User)) {
     CreateReturn('661');
 }
+
 $Galaxy        = (isset($_POST['galaxy']) ? intval($_POST['galaxy']) : 0);
 $System        = (isset($_POST['system']) ? intval($_POST['system']) : 0);
 $Planet        = (isset($_POST['planet']) ? intval($_POST['planet']) : 0);

--- a/ajax/sendmissiles.php
+++ b/ajax/sendmissiles.php
@@ -23,8 +23,8 @@ if(!isLogged())
 {
     CreateReturn('601');
 }
-if(!empty($_User['activation_code']))
-{
+
+if (!isUserAccountActivated($_User)) {
     CreateReturn('661');
 }
 

--- a/ajax/sendmissiles.php
+++ b/ajax/sendmissiles.php
@@ -9,7 +9,10 @@ $_SetAccessLogPreFilename = 'ajax/';
 $_SetAccessLogPath = '../';
 $_EnginePath = '../';
 
-include($_EnginePath.'common.php');
+include($_EnginePath . 'common.php');
+include($_EnginePath . 'modules/flightControl/_includes.php');
+
+use UniEngine\Engine\Modules\FlightControl;
 
 function CreateReturn($ReturnCode, $Update = '0')
 {
@@ -32,9 +35,13 @@ $Now = time();
 
 $FlyingFleets = doquery("SELECT COUNT(`fleet_id`) as `Number` FROM {{table}} WHERE `fleet_owner` = '{$_User['id']}';", 'fleets', true);
 $FlyingFleets = $FlyingFleets['Number'];
-$MaxFleets = 1 + $_User[$_Vars_GameElements[108]] + (($_User['admiral_time'] > $Now) ? 2 : 0);
-if($FlyingFleets >= $MaxFleets)
-{
+
+$MaxFleets = FlightControl\Utils\Helpers\getUserFleetSlotsCount([
+    'user' => $_User,
+    'timestamp' => $Now,
+]);
+
+if ($FlyingFleets >= $MaxFleets) {
     CreateReturn('609');
 }
 

--- a/fleet.php
+++ b/fleet.php
@@ -992,13 +992,14 @@ if (
     $JSSetShipsCount = [];
 
     foreach ($transportShipIds as $shipId) {
-        $shipCapacity = $_Vars_Prices[$shipId]['capacity'];
+        $shipPlanetKey = _getElementPlanetKey($shipId);
+        $shipCapacity = getShipsStorageCapacity($shipId);
 
         $shipsNeeded = ceil($resourcesToLoad / $shipCapacity);
         $shipsToUse = (
-            $shipsNeeded > $_Planet[$_Vars_GameElements[$shipId]] ?
-            $_Planet[$_Vars_GameElements[$shipId]] :
-            $shipsNeeded
+            $shipsNeeded <= $_Planet[$shipPlanetKey] ?
+            $shipsNeeded :
+            $_Planet[$shipPlanetKey]
         );
 
         $JSSetShipsCount[$shipId] = ((string) $shipsToUse);

--- a/fleet.php
+++ b/fleet.php
@@ -52,9 +52,6 @@ $InsertChronoApplets = '';
 
 $Hide = ' class="hide"';
 
-$FlyingFleetsCount = 0;
-$FlyingExpeditions = 0;
-
 $missiontype = array
 (
     1 => $_Lang['type_mission'][1],
@@ -142,16 +139,12 @@ else
     $_Lang['P_HideRetreatBox'] = $Hide;
 }
 
-// Get FlyingFleets Count
-$SQLResult_GetFlyingFleets = doquery("SELECT `fleet_mission` FROM {{table}} WHERE `fleet_owner` = {$_User['id']};", 'fleets');
-while($FleetData = $SQLResult_GetFlyingFleets->fetch_assoc())
-{
-    $FlyingFleetsCount += 1;
-    if($FleetData['fleet_mission'] == 15)
-    {
-        $FlyingExpeditions += 1;
-    }
-}
+$fleetsInFlightCounters = FlightControl\Utils\Helpers\getFleetsInFlightCounters([
+    'userId' => $_User['id'],
+]);
+
+$FlyingFleetsCount = $fleetsInFlightCounters['allFleetsInFlight'];
+$FlyingExpeditions = $fleetsInFlightCounters['expeditionsInFlight'];
 
 // Get Available Slots for Expeditions (1 + floor(ExpeditionTech / 3))
 $_Lang['P_MaxFleetSlots'] = FlightControl\Utils\Helpers\getUserFleetSlotsCount([

--- a/fleet.php
+++ b/fleet.php
@@ -5,6 +5,9 @@ define('INSIDE', true);
 $_EnginePath = './';
 
 include($_EnginePath.'common.php');
+include($_EnginePath . 'modules/flightControl/_includes.php');
+
+use UniEngine\Engine\Modules\FlightControl;
 
 loggedCheck();
 
@@ -150,9 +153,11 @@ while($FleetData = $SQLResult_GetFlyingFleets->fetch_assoc())
     }
 }
 
-// Get Available Slots for Fleets (1 + ComputerTech + 2 on Admiral)
 // Get Available Slots for Expeditions (1 + floor(ExpeditionTech / 3))
-$_Lang['P_MaxFleetSlots']        = 1 + $_User[$_Vars_GameElements[108]] + (($_User['admiral_time'] > $Now) ? 2 : 0);
+$_Lang['P_MaxFleetSlots'] = FlightControl\Utils\Helpers\getUserFleetSlotsCount([
+    'user' => $_User,
+    'timestamp' => $Now,
+]);
 $_Lang['P_MaxExpedSlots']        = 1 + floor($_User[$_Vars_GameElements[124]] / 3);
 $_Lang['P_FlyingFleetsCount']    = (string)($FlyingFleetsCount + 0);
 $_Lang['P_FlyingExpeditions']    = (string)($FlyingExpeditions + 0);

--- a/fleet.php
+++ b/fleet.php
@@ -1007,24 +1007,13 @@ if(isset($_GET['quickres']) && $_GET['quickres'] == 1)
         }
     }
 
-    if(!empty($JSSetShipsCount))
-    {
+    if (!empty($JSSetShipsCount)) {
         $_Lang['InsertJSShipSet'] = "var JSShipSet = new Object;\n";
-        foreach($JSSetShipsCount as $ShipID => $ShipCount)
-        {
-            $ShipCount = ceil($ShipCount);
-            if($_Planet[$_Vars_GameElements[$ShipID]] > 0)
-            {
-                if($ShipCount == 'max')
-                {
-                    $ShipCount = $_Planet[$_Vars_GameElements[$ShipID]];
-                }
-                else if($ShipCount > $_Planet[$_Vars_GameElements[$ShipID]])
-                {
-                    $ShipCount = $_Planet[$_Vars_GameElements[$ShipID]];
-                }
-                $_Lang['InsertJSShipSet'] .= "JSShipSet['{$ShipID}'] = {$ShipCount};\n";
-            }
+
+        foreach ($JSSetShipsCount as $shipId => $shipsCount) {
+            $shipsCount = ((string) $shipsCount);
+
+            $_Lang['InsertJSShipSet'] .= "JSShipSet['{$shipId}'] = {$shipsCount};\n";
         }
     }
 }

--- a/fleet.php
+++ b/fleet.php
@@ -974,8 +974,11 @@ if(!isPro())
     // Don't Allow to use this function to NonPro Players
     $_GET['quickres'] = 0;
 }
-if(isset($_GET['quickres']) && $_GET['quickres'] == 1)
-{
+
+if (
+    isset($_GET['quickres']) &&
+    $_GET['quickres'] == 1
+) {
     $_Lang['P_SetQuickRes'] = '1';
 
     $resourcesToLoad = (
@@ -1012,9 +1015,7 @@ if(isset($_GET['quickres']) && $_GET['quickres'] == 1)
 
         $_Lang['InsertJSShipSet'] = "var JSShipSet = {$jsShipsObject};\n";
     }
-}
-else
-{
+} else {
     $_Lang['P_SetQuickRes'] = '0';
 }
 

--- a/fleet.php
+++ b/fleet.php
@@ -154,8 +154,8 @@ $_Lang['P_MaxFleetSlots'] = FlightControl\Utils\Helpers\getUserFleetSlotsCount([
 $_Lang['P_MaxExpedSlots'] = FlightControl\Utils\Helpers\getUserExpeditionSlotsCount([
     'user' => $_User,
 ]);
-$_Lang['P_FlyingFleetsCount']    = (string)($FlyingFleetsCount + 0);
-$_Lang['P_FlyingExpeditions']    = (string)($FlyingExpeditions + 0);
+$_Lang['P_FlyingFleetsCount']    = (string)($FlyingFleetsCount);
+$_Lang['P_FlyingExpeditions']    = (string)($FlyingExpeditions);
 $_Lang['P_Expeditions_isHidden_style'] = (
     isFeatureEnabled(FeatureType::Expeditions) ?
     '' :

--- a/fleet.php
+++ b/fleet.php
@@ -158,7 +158,9 @@ $_Lang['P_MaxFleetSlots'] = FlightControl\Utils\Helpers\getUserFleetSlotsCount([
     'user' => $_User,
     'timestamp' => $Now,
 ]);
-$_Lang['P_MaxExpedSlots']        = 1 + floor($_User[$_Vars_GameElements[124]] / 3);
+$_Lang['P_MaxExpedSlots'] = FlightControl\Utils\Helpers\getUserExpeditionSlotsCount([
+    'user' => $_User,
+]);
 $_Lang['P_FlyingFleetsCount']    = (string)($FlyingFleetsCount + 0);
 $_Lang['P_FlyingExpeditions']    = (string)($FlyingExpeditions + 0);
 $_Lang['P_Expeditions_isHidden_style'] = (

--- a/fleet.php
+++ b/fleet.php
@@ -977,44 +977,33 @@ if(!isPro())
 if(isset($_GET['quickres']) && $_GET['quickres'] == 1)
 {
     $_Lang['P_SetQuickRes'] = '1';
-    $TotalResStorage = floor($_Planet['metal']) + floor($_Planet['crystal']) + floor($_Planet['deuterium']);
-    $TotalShipsStorage[217] = $_Planet[$_Vars_GameElements[217]] * $_Vars_Prices[217]['capacity'];
-    $TotalShipsStorage[203] = $_Planet[$_Vars_GameElements[203]] * $_Vars_Prices[203]['capacity'];
-    $TotalShipsStorage[202] = $_Planet[$_Vars_GameElements[202]] * $_Vars_Prices[202]['capacity'];
-    $TotalShipsStorage['all'] = array_sum($TotalShipsStorage);
-    if($TotalResStorage >= $TotalShipsStorage['all'])
-    {
-        $JSSetShipsCount[217] = 'max';
-        $JSSetShipsCount[203] = 'max';
-        $JSSetShipsCount[202] = 'max';
-    }
-    else
-    {
-        if($TotalResStorage >= $TotalShipsStorage[217])
-        {
-            $JSSetShipsCount[217] = 'max';
-            $TotalResStorage -= $TotalShipsStorage[217];
-            if($TotalResStorage >= $TotalShipsStorage[203])
-            {
-                $JSSetShipsCount[203] = 'max';
-                $TotalResStorage -= $TotalShipsStorage[203];
-                if($TotalResStorage >= $TotalShipsStorage[202])
-                {
-                    $JSSetShipsCount[202] = 'max';
-                }
-                else
-                {
-                    $JSSetShipsCount[202] = $TotalResStorage / $_Vars_Prices[202]['capacity'];
-                }
-            }
-            else
-            {
-                $JSSetShipsCount[203] = $TotalResStorage / $_Vars_Prices[203]['capacity'];
-            }
-        }
-        else
-        {
-            $JSSetShipsCount[217] = $TotalResStorage / $_Vars_Prices[217]['capacity'];
+
+    $resourcesToLoad = (
+        floor($_Planet['metal']) +
+        floor($_Planet['crystal']) +
+        floor($_Planet['deuterium'])
+    );
+
+    $transportShipIds = [ 217, 203, 202 ];
+
+    $JSSetShipsCount = [];
+
+    foreach ($transportShipIds as $shipId) {
+        $shipCapacity = $_Vars_Prices[$shipId]['capacity'];
+
+        $shipsNeeded = ceil($resourcesToLoad / $shipCapacity);
+        $shipsToUse = (
+            $shipsNeeded > $_Planet[$_Vars_GameElements[$shipId]] ?
+            $_Planet[$_Vars_GameElements[$shipId]] :
+            $shipsNeeded
+        );
+
+        $JSSetShipsCount[$shipId] = $shipsToUse;
+
+        $resourcesToLoad -= ($shipsToUse * $shipCapacity);
+
+        if ($resourcesToLoad <= 0) {
+            break;
         }
     }
 

--- a/fleet.php
+++ b/fleet.php
@@ -146,7 +146,6 @@ $fleetsInFlightCounters = FlightControl\Utils\Helpers\getFleetsInFlightCounters(
 $FlyingFleetsCount = $fleetsInFlightCounters['allFleetsInFlight'];
 $FlyingExpeditions = $fleetsInFlightCounters['expeditionsInFlight'];
 
-// Get Available Slots for Expeditions (1 + floor(ExpeditionTech / 3))
 $_Lang['P_MaxFleetSlots'] = FlightControl\Utils\Helpers\getUserFleetSlotsCount([
     'user' => $_User,
     'timestamp' => $Now,

--- a/fleet.php
+++ b/fleet.php
@@ -998,7 +998,7 @@ if(isset($_GET['quickres']) && $_GET['quickres'] == 1)
             $shipsNeeded
         );
 
-        $JSSetShipsCount[$shipId] = $shipsToUse;
+        $JSSetShipsCount[$shipId] = ((string) $shipsToUse);
 
         $resourcesToLoad -= ($shipsToUse * $shipCapacity);
 
@@ -1008,13 +1008,9 @@ if(isset($_GET['quickres']) && $_GET['quickres'] == 1)
     }
 
     if (!empty($JSSetShipsCount)) {
-        $_Lang['InsertJSShipSet'] = "var JSShipSet = new Object;\n";
+        $jsShipsObject = json_encode($JSSetShipsCount);
 
-        foreach ($JSSetShipsCount as $shipId => $shipsCount) {
-            $shipsCount = ((string) $shipsCount);
-
-            $_Lang['InsertJSShipSet'] .= "JSShipSet['{$shipId}'] = {$shipsCount};\n";
-        }
+        $_Lang['InsertJSShipSet'] = "var JSShipSet = {$jsShipsObject};\n";
     }
 }
 else

--- a/fleet2.php
+++ b/fleet2.php
@@ -138,30 +138,12 @@ if(isset($TargetError))
     message($_Lang['fl2_targeterror'], $ErrorTitle, 'fleet.php', 3);
 }
 
-// Create SpeedsArray
-$SpeedsAvailable = array(10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
+$availableSpeeds = FlightControl\Utils\Helpers\getAvailableSpeeds([
+    'user' => &$_User,
+    'timestamp' => $Now,
+]);
 
-if($_User['admiral_time'] > $Now)
-{
-    $SpeedsAvailable[] = 12;
-    $SpeedsAvailable[] = 11;
-    $SpeedsAvailable[] = 0.5;
-    $SpeedsAvailable[] = 0.25;
-}
-if(MORALE_ENABLED)
-{
-    $MaxAvailableSpeed = max($SpeedsAvailable);
-    if($_User['morale_level'] >= MORALE_BONUS_FLEETSPEEDUP1)
-    {
-        $SpeedsAvailable[] = $MaxAvailableSpeed + (MORALE_BONUS_FLEETSPEEDUP1_VALUE / 10);
-    }
-    if($_User['morale_level'] >= MORALE_BONUS_FLEETSPEEDUP2)
-    {
-        $SpeedsAvailable[] = $MaxAvailableSpeed + (MORALE_BONUS_FLEETSPEEDUP2_VALUE / 10);
-    }
-}
-if(!in_array($_POST['speed'], $SpeedsAvailable))
-{
+if (!in_array($_POST['speed'], $availableSpeeds)) {
     message($_Lang['fl_bad_fleet_speed'], $ErrorTitle, 'fleet.php', 3);
 }
 

--- a/fleet2.php
+++ b/fleet2.php
@@ -281,61 +281,15 @@ if($Fleet['count'] <= 0)
 $Fleet['array'] = $FleetArray;
 unset($FleetArray);
 
-// Create Array of Available Missions
-$AvailableMissions = array();
-if($Target['type'] == 2)
-{
-    if($Fleet['array'][209] > 0)
-    {
-        $AvailableMissions[] = 8;
-    }
-}
-else
-{
-    if($UsedPlanet)
-    {
-        if(!isset($Fleet['array'][210]) || $Fleet['count'] > $Fleet['array'][210])
-        {
-            $AvailableMissions[] = 3;
-        }
-        if(!$YourPlanet)
-        {
-            $AvailableMissions[] = 1;
-            if($OwnerFriend)
-            {
-                $AvailableMissions[] = 5;
-            }
-            if(isset($Fleet['array'][210]) && $Fleet['count'] == $Fleet['array'][210])
-            {
-                $AvailableMissions[] = 6;
-            }
-            if($Target['type'] == 3 && isset($Fleet['array'][214]) && $Fleet['array'][214] > 0)
-            {
-                $AvailableMissions[] = 9;
-            }
-        }
-        else
-        {
-            $AvailableMissions[] = 4;
-        }
-    }
-    else
-    {
-        if($Target['planet'] == (MAX_PLANET_IN_SYSTEM + 1))
-        {
-            if (isFeatureEnabled(FeatureType::Expeditions)) {
-                $AvailableMissions[] = 15;
-            }
-        }
-        else
-        {
-            if($Fleet['array'][208] > 0 AND $Target['type'] == 1)
-            {
-                $AvailableMissions[] = 7;
-            }
-        }
-    }
-}
+$AvailableMissions = FlightControl\Utils\Helpers\getValidMissionTypes([
+    'targetCoordinates' => $Target,
+    'fleetShips' => $Fleet['array'],
+    'fleetShipsCount' => $Fleet['count'],
+    'isPlanetOccupied' => $UsedPlanet,
+    'isPlanetOwnedByUser' => $YourPlanet,
+    'isPlanetOwnedByUsersFriend' => $OwnerFriend,
+    'isUnionMissionAllowed' => false,
+]);
 
 if(in_array(1, $AvailableMissions) && $CheckPlanetOwner['id'] > 0)
 {

--- a/fleet2.php
+++ b/fleet2.php
@@ -158,29 +158,16 @@ $UsedPlanet                    = false;
 $OwnerFriend                = false;
 $OwnerHasMarcantilePact        = false;
 $AllyPactWarning            = false;
-$CheckPlanetOwnerQuery = '';
-$CheckPlanetOwnerQuery .= "SELECT `planets`.`id`, `planets`.`id_owner` AS `owner`, `planets`.`name` AS `name`, `quantumgate`, ";
-$CheckPlanetOwnerQuery .= "`users`.`ally_id`, `users`.`username` as `username`, `buddy1`.`active` AS `active1`, `buddy2`.`active` AS `active2` ";
-if($_User['ally_id'] > 0)
-{
-    $CheckPlanetOwnerQuery .= ", `apact1`.`Type` AS `AllyPact1`, `apact2`.`Type` AS `AllyPact2` ";
-}
-$CheckPlanetOwnerQuery .= "FROM {{table}} AS `planets` ";
-$CheckPlanetOwnerQuery .= "LEFT JOIN `{{prefix}}buddy` AS `buddy1` ON (`planets`.`id_owner` = `buddy1`.`sender` AND `buddy1`.`owner` = {$_User['id']}) ";
-$CheckPlanetOwnerQuery .= "LEFT JOIN `{{prefix}}buddy` AS `buddy2` ON (`planets`.`id_owner` = `buddy2`.`owner` AND `buddy2`.`sender` = {$_User['id']}) ";
-$CheckPlanetOwnerQuery .= "LEFT JOIN `{{prefix}}users` AS `users` ON `planets`.`id_owner` = `users`.`id` ";
-if($_User['ally_id'] > 0)
-{
-    $CheckPlanetOwnerQuery .= "LEFT JOIN `{{prefix}}ally_pacts` AS `apact1` ON (`apact1`.`AllyID_Sender` = {$_User['ally_id']} AND `apact1`.`AllyID_Owner` = `users`.`ally_id` AND `apact1`.`Active` = 1) ";
-    $CheckPlanetOwnerQuery .= "LEFT JOIN `{{prefix}}ally_pacts` AS `apact2` ON (`apact2`.`AllyID_Sender` = `users`.`ally_id` AND `apact2`.`AllyID_Owner` = {$_User['ally_id']} AND `apact2`.`Active` = 1) ";
-}
-$CheckPlanetOwnerQuery .= "WHERE `planets`.`galaxy` = {$Target['galaxy']} AND `planets`.`system` = {$Target['system']} AND `planets`.`planet` = {$Target['planet']} AND `planets`.`planet_type` = {$Target['type']} ";
-$CheckPlanetOwnerQuery .= "LIMIT 1;";
-$CheckPlanetOwner = doquery($CheckPlanetOwnerQuery, 'planets');
 
-if($CheckPlanetOwner->num_rows == 1)
-{
-    $CheckPlanetOwner = $CheckPlanetOwner->fetch_assoc();
+$planetOwnerDetails = FlightControl\Utils\Fetchers\fetchPlanetOwnerDetails([
+    'targetCoordinates' => $Target,
+    'user' => &$_User,
+    'isExtendedUserDetailsEnabled' => false,
+]);
+
+if ($planetOwnerDetails) {
+    $CheckPlanetOwner = $planetOwnerDetails;
+
     $UsedPlanet = true;
     if($CheckPlanetOwner['owner'] == $_User['id'])
     {

--- a/fleet2.php
+++ b/fleet2.php
@@ -19,6 +19,11 @@ if((!isset($_POST['sending_fleet']) || $_POST['sending_fleet'] != '1') && (!isse
 
 $_Lang['SelectResources'] = 'false';
 $_Lang['SelectQuantumGate'] = 'false';
+
+$setFormValues = [
+    'holdingtime' => null,
+];
+
 if(!empty($_POST['gobackVars']))
 {
     $_POST['gobackVars'] = json_decode(base64_decode($_POST['gobackVars']), true);
@@ -36,7 +41,7 @@ if(!empty($_POST['gobackVars']))
     }
     if(isset($_POST['gobackVars']['holdingtime']))
     {
-        $_Lang['SelectHolding_'.$_POST['gobackVars']['holdingtime']] = 'selected';
+        $setFormValues['holdingtime'] = $_POST['gobackVars']['holdingtime'];
     }
     if(isset($_POST['gobackVars']['expeditiontime']))
     {
@@ -667,6 +672,28 @@ else
 {
     $_Lang['Insert_AllyPact_AttackWarn'] = 'false';
 }
+
+$availableHoldTimes = FlightControl\Utils\Helpers\getAvailableHoldTimes([]);
+
+$missionHoldTimeOptions = array_map(
+    function ($holdTimeValue) use ($setFormValues) {
+        return buildDOMElementHTML([
+            'tagName' => 'option',
+            'contentHTML' => $holdTimeValue,
+            'attrs' => [
+                'value' => $holdTimeValue,
+                'selected' => (
+                    $holdTimeValue == $setFormValues['holdingtime'] ?
+                        '' :
+                        null
+                ),
+            ],
+        ]);
+    },
+    $availableHoldTimes
+);
+
+$_Lang['P_HTMLBuilder_MissionHold_AvailableTimes'] = implode('', $missionHoldTimeOptions);
 
 display(parsetemplate(gettemplate('fleet2_body'), $_Lang), $_Lang['fl_title']);
 

--- a/fleet2.php
+++ b/fleet2.php
@@ -153,28 +153,25 @@ if (!in_array($_POST['speed'], $availableSpeeds)) {
 }
 
 // Check PlanetOwner
-$YourPlanet                    = false;
-$UsedPlanet                    = false;
-$OwnerFriend                = false;
-$OwnerHasMarcantilePact        = false;
-$AllyPactWarning            = false;
-
 $planetOwnerDetails = FlightControl\Utils\Fetchers\fetchPlanetOwnerDetails([
     'targetCoordinates' => $Target,
     'user' => &$_User,
     'isExtendedUserDetailsEnabled' => false,
 ]);
 
+$isPlanetOccupied = !empty($planetOwnerDetails);
+
+$YourPlanet = false;
+$OwnerFriend = false;
+$OwnerHasMarcantilePact = false;
+$AllyPactWarning = false;
+
 if ($planetOwnerDetails) {
     $CheckPlanetOwner = $planetOwnerDetails;
 
-    $UsedPlanet = true;
-    if($CheckPlanetOwner['owner'] == $_User['id'])
-    {
+    if ($CheckPlanetOwner['owner'] == $_User['id']) {
         $YourPlanet = true;
-    }
-    else
-    {
+    } else {
         if(!empty($_GameConfig['TestUsersIDs']))
         {
             $TestUsersArray = explode(',', $_GameConfig['TestUsersIDs']);
@@ -272,7 +269,7 @@ $AvailableMissions = FlightControl\Utils\Helpers\getValidMissionTypes([
     'targetCoordinates' => $Target,
     'fleetShips' => $Fleet['array'],
     'fleetShipsCount' => $Fleet['count'],
-    'isPlanetOccupied' => $UsedPlanet,
+    'isPlanetOccupied' => $isPlanetOccupied,
     'isPlanetOwnedByUser' => $YourPlanet,
     'isPlanetOwnedByUsersFriend' => $OwnerFriend,
     'isUnionMissionAllowed' => false,

--- a/fleet3.php
+++ b/fleet3.php
@@ -455,6 +455,8 @@ $validMissionTypes = FlightControl\Utils\Helpers\getValidMissionTypes([
     'isPlanetOccupied' => $UsedPlanet,
     'isPlanetOwnedByUser' => $YourPlanet,
     'isPlanetOwnedByUsersFriend' => $OwnerFriend,
+    // TODO: additional pre-validation might be needed
+    'isUnionMissionAllowed' => true,
 ]);
 
 // --- Check if everything is OK with ACS

--- a/fleet3.php
+++ b/fleet3.php
@@ -561,9 +561,6 @@ if(!in_array($Fleet['Mission'], $validMissionTypes))
         messageRed($_Lang['fl3_CantRecycleNoShip'], $ErrorTitle);
     }
     if ($Fleet['Mission'] == 9) {
-        if ($Target['type'] == 2) {
-            messageRed($_Lang['fl3_CantDestroyDebris'], $ErrorTitle);
-        }
         if ($Target['type'] != 3) {
             messageRed($_Lang['fl3_CantDestroyNonMoon'], $ErrorTitle);
         }

--- a/fleet3.php
+++ b/fleet3.php
@@ -209,38 +209,19 @@ $PlanetAbandoned            = false;
 
 if($Fleet['Mission'] != 8)
 {
-    // This is not a Recycling Mission, so check Planet Data
-    $Query_CheckPlanetOwner = '';
-    $Query_CheckPlanetOwner .= "SELECT `pl`.`id` AS `id`, `pl`.`id_owner` AS `owner`, `pl`.`name` AS `name`, `pl`.`quantumgate`, ";
-    $Query_CheckPlanetOwner .= "`users`.`ally_id`, `users`.`onlinetime`, `users`.`username` as `username`, `users`.`user_lastip` as `lastip`, `users`.`is_onvacation`, `users`.`is_banned`, `users`.`authlevel`, `users`.`first_login`, `users`.`NoobProtection_EndTime`, `users`.`multiIP_DeclarationID`, ";
-    $Query_CheckPlanetOwner .= "`stats`.`total_rank`, `stats`.`total_points`, `buddy1`.`active` AS `active1`, `buddy2`.`active` AS `active2` ";
-    if($_User['ally_id'] > 0)
-    {
-        $Query_CheckPlanetOwner .= ", `apact1`.`Type` AS `AllyPact1`, `apact2`.`Type` AS `AllyPact2` ";
-    }
-    $Query_CheckPlanetOwner .= "FROM {{table}} as `pl` ";
-    $Query_CheckPlanetOwner .= "LEFT JOIN {{prefix}}buddy as `buddy1` ON (`pl`.`id_owner` = `buddy1`.`sender` AND `buddy1`.`owner` = {$_User['id']}) ";
-    $Query_CheckPlanetOwner .= "LEFT JOIN {{prefix}}buddy as `buddy2` ON (`pl`.`id_owner` = `buddy2`.`owner` AND `buddy2`.`sender` = {$_User['id']}) ";
-    $Query_CheckPlanetOwner .= "LEFT JOIN {{prefix}}users as `users` ON `pl`.`id_owner` = `users`.`id` ";
-    $Query_CheckPlanetOwner .= "LEFT JOIN {{prefix}}statpoints AS `stats` ON `pl`.`id_owner` = `stats`.`id_owner` AND `stat_type` = '1' ";
-    if($_User['ally_id'] > 0)
-    {
-        $Query_CheckPlanetOwner .= "LEFT JOIN `{{prefix}}ally_pacts` AS `apact1` ON (`apact1`.`AllyID_Sender` = {$_User['ally_id']} AND `apact1`.`AllyID_Owner` = `users`.`ally_id` AND `apact1`.`Active` = 1) ";
-        $Query_CheckPlanetOwner .= "LEFT JOIN `{{prefix}}ally_pacts` AS `apact2` ON (`apact2`.`AllyID_Sender` = `users`.`ally_id` AND `apact2`.`AllyID_Owner` = {$_User['ally_id']} AND `apact2`.`Active` = 1) ";
-    }
-    $Query_CheckPlanetOwner .= "WHERE `pl`.`galaxy` = {$Target['galaxy']} AND `pl`.`system` = {$Target['system']} AND `pl`.`planet` = {$Target['planet']} AND `pl`.`planet_type` = {$Target['type']} ";
-    $Query_CheckPlanetOwner .= "LIMIT 1;";
+    $planetOwnerDetails = FlightControl\Utils\Fetchers\fetchPlanetOwnerDetails([
+        'targetCoordinates' => $Target,
+        'user' => &$_User,
+        'isExtendedUserDetailsEnabled' => true,
+    ]);
 
-    $SQLResult_GetPlanetData = doquery($Query_CheckPlanetOwner, 'planets');
-
-    if($SQLResult_GetPlanetData->num_rows == 1)
-    {
+    if ($planetOwnerDetails) {
         $CheckGalaxyRow = doquery(
             "SELECT `galaxy_id` FROM {{table}} WHERE `galaxy` = {$Target['galaxy']} AND `system` = {$Target['system']} AND `planet` = {$Target['planet']} LIMIT 1;", 'galaxy',
             true
         );
 
-        $CheckPlanetOwner = $SQLResult_GetPlanetData->fetch_assoc();
+        $CheckPlanetOwner = $planetOwnerDetails;
 
         $CheckPlanetOwner['galaxy_id'] = $CheckGalaxyRow['galaxy_id'];
         $UsedPlanet = true;
@@ -277,7 +258,7 @@ if($Fleet['Mission'] != 8)
     }
     else
     {
-        $CheckPlanetOwner = array();
+        $CheckPlanetOwner = [];
     }
 }
 else

--- a/fleet3.php
+++ b/fleet3.php
@@ -469,201 +469,120 @@ $Throw = false;
 // --- If Mission is not correct, show Error
 if(!in_array($Fleet['Mission'], $validMissionTypes))
 {
-    switch($Fleet['Mission'])
-    {
-        case 1:
-            if($Target['type'] == 2)
-            {
-                $Throw = $_Lang['fl3_CantAttackDebris'];
-            }
-            else
-            {
-                if(!$UsedPlanet)
-                {
-                    $Throw = $_Lang['fl3_CantAttackNonUsed'];
-                }
-                else
-                {
-                    if($YourPlanet)
-                    {
-                        $Throw = $_Lang['fl3_CantAttackYourself'];
-                    }
-                }
-            }
-            break;
-        case 2:
-            if($Target['type'] == 2)
-            {
-                $Throw = $_Lang['fl3_CantACSDebris'];
-            }
-            else
-            {
-                if(!$UsedPlanet)
-                {
-                    $Throw = $_Lang['fl3_CantACSNonUsed'];
-                }
-                else
-                {
-                    if($YourPlanet)
-                    {
-                        $Throw = $_Lang['fl3_CantACSYourself'];
-                    }
-                }
-            }
-            break;
-        case 3:
-            if($Target['type'] == 2)
-            {
-                $Throw = $_Lang['fl3_CantTransportDebris'];
-            }
-            else
-            {
-                if(!$UsedPlanet)
-                {
-                    $Throw = $_Lang['fl3_CantTransportNonUsed'];
-                }
-                else
-                {
-                    $Throw = $_Lang['fl3_CantTransportSpyProbes'];
-                }
-            }
-            break;
-        case 4:
-            if($Target['type'] == 2)
-            {
-                $Throw = $_Lang['fl3_CantStayDebris'];
-            }
-            else
-            {
-                if(!$UsedPlanet)
-                {
-                    $Throw = $_Lang['fl3_CantStayNonUsed'];
-                }
-                else
-                {
-                    if(!$YourPlanet)
-                    {
-                        $Throw = $_Lang['fl3_CantStayNonYourself'];
-                    }
-                }
-            }
-            break;
-        case 5:
-            if($Target['type'] == 2)
-            {
-                $Throw = $_Lang['fl3_CantProtectDebris'];
-            }
-            else
-            {
-                if(!$UsedPlanet)
-                {
-                    $Throw = $_Lang['fl3_CantProtectNonUsed'];
-                }
-                else
-                {
-                    if($YourPlanet)
-                    {
-                        $Throw = $_Lang['fl3_CantProtectYourself'];
-                    }
-                    else
-                    {
-                        $Throw = $_Lang['fl3_CantProtectNonFriend'];
-                    }
-                }
-            }
-            break;
-        case 6:
-            if($Target['type'] == 2)
-            {
-                $Throw = $_Lang['fl3_CantSpyDebris'];
-            }
-            else
-            {
-                if(!$UsedPlanet)
-                {
-                    $Throw = $_Lang['fl3_CantSpyNonUsed'];
-                }
-                else
-                {
-                    if($YourPlanet)
-                    {
-                        $Throw = $_Lang['fl3_CantSpyYourself'];
-                    }
-                    else
-                    {
-                        $Throw = $_Lang['fl3_CantSpyProbesCount'];
-                    }
-                }
-            }
-            break;
-        case 7:
-            if($UsedPlanet)
-            {
-                $Throw = $_Lang['fl3_CantSettleOnUsed'];
-            }
-            else
-            {
-                if($Target['type'] != 1)
-                {
-                    $Throw = $_Lang['fl3_CantSettleNonPlanet'];
-                }
-                else
-                {
-                    $Throw = $_Lang['fl3_CantSettleNoShips'];
-                }
-            }
-            break;
-        case 8:
-            if($Target['type'] != 2)
-            {
-                $Throw = $_Lang['fl3_CantRecycleNonDebris'];
-            }
-            else
-            {
-                $Throw = $_Lang['fl3_CantRecycleNoShip'];
-            }
-            break;
-        case 9:
-            if($Target['type'] == 2)
-            {
-                $Throw = $_Lang['fl3_CantDestroyDebris'];
-            }
-            else
-            {
-                if(!$UsedPlanet)
-                {
-                    $Throw = $_Lang['fl3_CantDestroyNonUsed'];
-                }
-                else
-                {
-                    if($YourPlanet)
-                    {
-                        $Throw = $_Lang['fl3_CantDestroyYourself'];
-                    }
-                    else
-                    {
-                        if($Target['type'] != 3)
-                        {
-                            $Throw = $_Lang['fl3_CantDestroyNonMoon'];
-                        }
-                        else
-                        {
-                            $Throw = $_Lang['fl3_CantDestroyNoShip'];
-                        }
-                    }
-                }
-            }
-            break;
-        case 15:
-            if (!isFeatureEnabled(\FeatureType::Expeditions)) {
-                $Throw = $_Lang['fl3_ExpeditionsAreOff'];
-            }
-            break;
+    if ($Fleet['Mission'] == 1) {
+        if ($Target['type'] == 2) {
+            messageRed($_Lang['fl3_CantAttackDebris'], $ErrorTitle);
+        }
+        if (!$UsedPlanet) {
+            messageRed($_Lang['fl3_CantAttackNonUsed'], $ErrorTitle);
+        }
+        if ($YourPlanet) {
+            messageRed($_Lang['fl3_CantAttackYourself'], $ErrorTitle);
+        }
     }
-    if($Throw)
-    {
-        messageRed($Throw, $ErrorTitle);
+    if ($Fleet['Mission'] == 2) {
+        if ($Target['type'] == 2) {
+            messageRed($_Lang['fl3_CantACSDebris'], $ErrorTitle);
+        }
+        if (!$UsedPlanet) {
+            messageRed($_Lang['fl3_CantACSNonUsed'], $ErrorTitle);
+        }
+        if ($YourPlanet) {
+            messageRed($_Lang['fl3_CantACSYourself'], $ErrorTitle);
+        }
     }
+    if ($Fleet['Mission'] == 3) {
+        if ($Target['type'] == 2) {
+            messageRed($_Lang['fl3_CantTransportDebris'], $ErrorTitle);
+        }
+        if (!$UsedPlanet) {
+            messageRed($_Lang['fl3_CantTransportNonUsed'], $ErrorTitle);
+        }
+        // TODO: This should be checked,
+        // to prevent from other error states from being caught by this
+        messageRed($_Lang['fl3_CantTransportSpyProbes'], $ErrorTitle);
+    }
+    if ($Fleet['Mission'] == 4) {
+        if ($Target['type'] == 2) {
+            messageRed($_Lang['fl3_CantStayDebris'], $ErrorTitle);
+        }
+        if (!$UsedPlanet) {
+            messageRed($_Lang['fl3_CantStayNonUsed'], $ErrorTitle);
+        }
+        if (!$YourPlanet) {
+            messageRed($_Lang['fl3_CantStayNonYourself'], $ErrorTitle);
+        }
+    }
+    if ($Fleet['Mission'] == 5) {
+        if ($Target['type'] == 2) {
+            messageRed($_Lang['fl3_CantProtectDebris'], $ErrorTitle);
+        }
+        if (!$UsedPlanet) {
+            messageRed($_Lang['fl3_CantProtectNonUsed'], $ErrorTitle);
+        }
+        if ($YourPlanet) {
+            messageRed($_Lang['fl3_CantProtectYourself'], $ErrorTitle);
+        }
+        // TODO: This should be checked,
+        // to prevent from other error states from being caught by this
+        messageRed($_Lang['fl3_CantProtectNonFriend'], $ErrorTitle);
+    }
+    if ($Fleet['Mission'] == 6) {
+        if ($Target['type'] == 2) {
+            messageRed($_Lang['fl3_CantSpyDebris'], $ErrorTitle);
+        }
+        if (!$UsedPlanet) {
+            messageRed($_Lang['fl3_CantSpyNonUsed'], $ErrorTitle);
+        }
+        if ($YourPlanet) {
+            messageRed($_Lang['fl3_CantSpyYourself'], $ErrorTitle);
+        }
+        // TODO: This should be checked,
+        // to prevent from other error states from being caught by this
+        messageRed($_Lang['fl3_CantSpyProbesCount'], $ErrorTitle);
+    }
+    if ($Fleet['Mission'] == 7) {
+        if ($Target['type'] != 1) {
+            messageRed($_Lang['fl3_CantSettleNonPlanet'], $ErrorTitle);
+        }
+        if ($UsedPlanet) {
+            messageRed($_Lang['fl3_CantSettleOnUsed'], $ErrorTitle);
+        }
+        // TODO: This should be checked,
+        // to prevent from other error states from being caught by this
+        messageRed($_Lang['fl3_CantSettleNoShips'], $ErrorTitle);
+    }
+    if ($Fleet['Mission'] == 8) {
+        if ($Target['type'] != 2) {
+            messageRed($_Lang['fl3_CantRecycleNonDebris'], $ErrorTitle);
+        }
+        // TODO: This should be checked,
+        // to prevent from other error states from being caught by this
+        messageRed($_Lang['fl3_CantRecycleNoShip'], $ErrorTitle);
+    }
+    if ($Fleet['Mission'] == 9) {
+        if ($Target['type'] == 2) {
+            messageRed($_Lang['fl3_CantDestroyDebris'], $ErrorTitle);
+        }
+        if ($Target['type'] != 3) {
+            messageRed($_Lang['fl3_CantDestroyNonMoon'], $ErrorTitle);
+        }
+        if (!$UsedPlanet) {
+            messageRed($_Lang['fl3_CantDestroyNonUsed'], $ErrorTitle);
+        }
+        if ($YourPlanet) {
+            messageRed($_Lang['fl3_CantDestroyYourself'], $ErrorTitle);
+        }
+        // TODO: This should be checked,
+        // to prevent from other error states from being caught by this
+        messageRed($_Lang['fl3_CantDestroyNoShip'], $ErrorTitle);
+    }
+    if ($Fleet['Mission'] == 15) {
+        if (!isFeatureEnabled(\FeatureType::Expeditions)) {
+            messageRed($_Lang['fl3_ExpeditionsAreOff'], $ErrorTitle);
+        }
+    }
+
     messageRed($_Lang['fl3_BadMissionSelected'], $ErrorTitle);
 }
 

--- a/fleet3.php
+++ b/fleet3.php
@@ -83,13 +83,6 @@ if($Fleet['Mission'] <= 0)
     messageRed($_Lang['fl3_NoMissionSelected'], $ErrorTitle);
 }
 
-if (
-    !isFeatureEnabled(FeatureType::Expeditions) &&
-    $Fleet['Mission'] == 15
-) {
-    messageRed($_Lang['fl3_ExpeditionsAreOff'], $ErrorTitle);
-}
-
 // --- Get FlyingFleets Count
 $FlyingFleetsCount = 0;
 $FlyingExpeditions = 0;
@@ -700,6 +693,11 @@ if(!in_array($Fleet['Mission'], $validMissionTypes))
                         }
                     }
                 }
+            }
+            break;
+        case 15:
+            if (!isFeatureEnabled(\FeatureType::Expeditions)) {
+                $Throw = $_Lang['fl3_ExpeditionsAreOff'];
             }
             break;
     }

--- a/fleet3.php
+++ b/fleet3.php
@@ -73,9 +73,7 @@ $Protections['bashLimit_interval'] = $_GameConfig['Protection_BashLimitInterval'
 $Protections['bashLimit_counttotal'] = $_GameConfig['Protection_BashLimitCountTotal'];
 $Protections['bashLimit_countplanet'] = $_GameConfig['Protection_BashLimitCountPlanet'];
 
-// --- Check if User's account is activated
-if(!empty($_User['activation_code']))
-{
+if (!isUserAccountActivated($_User)) {
     messageRed($_Lang['fl3_BlockAccNotActivated'], $ErrorTitle);
 }
 

--- a/fleet3.php
+++ b/fleet3.php
@@ -199,13 +199,13 @@ if (!in_array($Fleet['Speed'], $availableSpeeds)) {
 }
 
 // --- Check PlanetOwner
-$YourPlanet                    = false;
-$UsedPlanet                    = false;
-$OwnerFriend                = false;
-$OwnerIsBuddyFriend            = false;
-$OwnerIsAlliedUser            = false;
-$OwnerHasMarcantilePact        = false;
-$PlanetAbandoned            = false;
+$YourPlanet = false;
+$UsedPlanet = false;
+$OwnerFriend = false;
+$OwnerIsBuddyFriend = false;
+$OwnerIsAlliedUser = false;
+$OwnerHasMarcantilePact = false;
+$PlanetAbandoned = false;
 
 if($Fleet['Mission'] != 8)
 {

--- a/fleet3.php
+++ b/fleet3.php
@@ -120,9 +120,11 @@ while($FleetData = $Result_GetFleets->fetch_assoc())
     }
 }
 
-// Get Available Slots for Fleets (1 + ComputerTech + 2 on Admiral)
 // Get Available Slots for Expeditions (1 + floor(ExpeditionTech / 3))
-$Slots['MaxFleetSlots'] = 1 + $_User[$_Vars_GameElements[108]] + (($_User['admiral_time'] > $Now) ? 2 : 0);
+$Slots['MaxFleetSlots'] = FlightControl\Utils\Helpers\getUserFleetSlotsCount([
+    'user' => $_User,
+    'timestamp' => $Now,
+]);
 $Slots['MaxExpedSlots'] = 1 + floor($_User[$_Vars_GameElements[124]] / 3);
 $Slots['FlyingFleetsCount'] = $FlyingFleetsCount;
 $Slots['FlyingExpeditions'] = $FlyingExpeditions;

--- a/fleet3.php
+++ b/fleet3.php
@@ -1451,29 +1451,14 @@ doquery('LOCK TABLE {{table}} WRITE', 'planets');
 doquery($QryUpdatePlanet, 'planets');
 doquery('UNLOCK TABLES', '');
 
-// User Development Log
-if($Fleet['resources']['metal'] > 0)
-{
-    $Add2UserDev_Log[] = 'M,'.$Fleet['resources']['metal'];
-}
-if($Fleet['resources']['crystal'] > 0)
-{
-    $Add2UserDev_Log[] = 'C,'.$Fleet['resources']['crystal'];
-}
-if($Fleet['resources']['deuterium'] > 0)
-{
-    $Add2UserDev_Log[] = 'D,'.$Fleet['resources']['deuterium'];
-}
-if($Consumption > 0)
-{
-    $Add2UserDev_Log[] = 'F,'.$Consumption;
-}
-$RTrim = rtrim($Fleet['array'], ';');
-if(!empty($Add2UserDev_Log))
-{
-    $Add2UserDev_Log = ';'.implode(';', $Add2UserDev_Log);
-}
-$UserDev_Log[] = array('PlanetID' => $_Planet['id'], 'Date' => $Now, 'Place' => 10, 'Code' => $Fleet['Mission'], 'ElementID' => $LastFleetID, 'AdditionalData' => $RTrim.$Add2UserDev_Log);
+$UserDev_Log[] = FlightControl\Utils\Factories\createFleetDevLogEntry([
+    'currentPlanet' => &$_Planet,
+    'newFleetId' => $LastFleetID,
+    'timestamp' => $Now,
+    'fleetData' => $Fleet,
+    'fuelUsage' => $Consumption,
+]);
+
 // ---
 
 $_Lang['FleetMission'] = $_Lang['type_mission'][$Fleet['Mission']];

--- a/fleet3.php
+++ b/fleet3.php
@@ -455,63 +455,17 @@ if($Fleet['count'] <= 0)
 $Fleet['array'] = $FleetArray;
 unset($FleetArray);
 
-// --- Create Array of Available Missions
-$AvailableMissions = array();
-if($Target['type'] == 2)
-{
-    if($Fleet['array'][209] > 0)
-    {
-        $AvailableMissions[] = 8;
-    }
-}
-else
-{
-    if($UsedPlanet)
-    {
-        if(!isset($Fleet['array'][210]) || $Fleet['count'] > $Fleet['array'][210])
-        {
-            $AvailableMissions[] = 3;
-        }
-        if(!$YourPlanet)
-        {
-            $AvailableMissions[] = 1;
-            $AvailableMissions[] = 2;
-            if($OwnerFriend)
-            {
-                $AvailableMissions[] = 5;
-            }
-            if(isset($Fleet['array'][210]) && $Fleet['count'] == $Fleet['array'][210])
-            {
-                $AvailableMissions[] = 6;
-            }
-            if($Target['type'] == 3 && isset($Fleet['array'][214]) && $Fleet['array'][214] > 0)
-            {
-                $AvailableMissions[] = 9;
-            }
-        }
-        else
-        {
-            $AvailableMissions[] = 4;
-        }
-    }
-    else
-    {
-        if($Target['planet'] == (MAX_PLANET_IN_SYSTEM + 1))
-        {
-            $AvailableMissions[] = 15;
-        }
-        else
-        {
-            if($Fleet['array'][208] > 0 AND $Target['type'] == 1)
-            {
-                $AvailableMissions[] = 7;
-            }
-        }
-    }
-}
+$validMissionTypes = FlightControl\Utils\Helpers\getValidMissionTypes([
+    'targetCoordinates' => $Target,
+    'fleetShips' => $Fleet['array'],
+    'fleetShipsCount' => $Fleet['count'],
+    'isPlanetOccupied' => $UsedPlanet,
+    'isPlanetOwnedByUser' => $YourPlanet,
+    'isPlanetOwnedByUsersFriend' => $OwnerFriend,
+]);
 
 // --- Check if everything is OK with ACS
-if ($Fleet['Mission'] == 2 AND in_array(2, $AvailableMissions)) {
+if ($Fleet['Mission'] == 2 AND in_array(2, $validMissionTypes)) {
     $joinUnionValidationResult = FlightControl\Utils\Validators\validateJoinUnion([
         'newFleet' => $Fleet,
         'timestamp' => $Now,
@@ -561,7 +515,7 @@ if ($Fleet['Mission'] == 2 AND in_array(2, $AvailableMissions)) {
 $Throw = false;
 
 // --- If Mission is not correct, show Error
-if(!in_array($Fleet['Mission'], $AvailableMissions))
+if(!in_array($Fleet['Mission'], $validMissionTypes))
 {
     switch($Fleet['Mission'])
     {

--- a/fleet3.php
+++ b/fleet3.php
@@ -194,30 +194,12 @@ if(isset($TargetError))
     messageRed($_Lang['fl2_targeterror'], $ErrorTitle);
 }
 
-// Create SpeedsArray
-$SpeedsAvailable = array(10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
+$availableSpeeds = FlightControl\Utils\Helpers\getAvailableSpeeds([
+    'user' => &$_User,
+    'timestamp' => $Now,
+]);
 
-if($_User['admiral_time'] > $Now)
-{
-    $SpeedsAvailable[] = 12;
-    $SpeedsAvailable[] = 11;
-    $SpeedsAvailable[] = 0.5;
-    $SpeedsAvailable[] = 0.25;
-}
-if(MORALE_ENABLED)
-{
-    $MaxAvailableSpeed = max($SpeedsAvailable);
-    if($_User['morale_level'] >= MORALE_BONUS_FLEETSPEEDUP1)
-    {
-        $SpeedsAvailable[] = $MaxAvailableSpeed + (MORALE_BONUS_FLEETSPEEDUP1_VALUE / 10);
-    }
-    if($_User['morale_level'] >= MORALE_BONUS_FLEETSPEEDUP2)
-    {
-        $SpeedsAvailable[] = $MaxAvailableSpeed + (MORALE_BONUS_FLEETSPEEDUP2_VALUE / 10);
-    }
-}
-if(!in_array($Fleet['Speed'], $SpeedsAvailable))
-{
+if (!in_array($Fleet['Speed'], $availableSpeeds)) {
     messageRed($_Lang['fl_bad_fleet_speed'], $ErrorTitle);
 }
 

--- a/fleet3.php
+++ b/fleet3.php
@@ -765,6 +765,28 @@ if($Fleet['Mission'] == 8)
     }
 }
 
+if ($Fleet['Mission'] == 5) {
+    $missionHoldValidationResult = FlightControl\Utils\Validators\validateMissionHold([
+        'newFleet' => $Fleet,
+    ]);
+
+    if (!$missionHoldValidationResult['isValid']) {
+        $firstValidationError = $missionHoldValidationResult['errors'][0];
+
+        $errorMessage = null;
+        switch ($firstValidationError['errorCode']) {
+            case 'INVALID_HOLD_TIME':
+                $errorMessage = $_Lang['fl3_Holding_BadTime'];
+                break;
+            default:
+                $errorMessage = $_Lang['fleet_generic_errors_unknown'];
+                break;
+        }
+
+        messageRed($errorMessage, $ErrorTitle);
+    }
+}
+
 // --- Check if Expeditions and HoldingTimes are Correct
 $Throw = false;
 $Fleet['StayTime'] = 0;
@@ -782,10 +804,6 @@ if($Fleet['Mission'] == 15)
 }
 elseif($Fleet['Mission'] == 5)
 {
-    if(!in_array($Fleet['HoldTime'], array(1, 2, 4, 8, 16, 32)))
-    {
-        $Throw = $_Lang['fl3_Holding_BadTime'];
-    }
     $Fleet['StayTime'] = $Fleet['HoldTime'] * 3600;
 }
 if($Throw)

--- a/fleet3.php
+++ b/fleet3.php
@@ -118,7 +118,9 @@ $Slots['MaxFleetSlots'] = FlightControl\Utils\Helpers\getUserFleetSlotsCount([
     'user' => $_User,
     'timestamp' => $Now,
 ]);
-$Slots['MaxExpedSlots'] = 1 + floor($_User[$_Vars_GameElements[124]] / 3);
+$Slots['MaxExpedSlots'] = FlightControl\Utils\Helpers\getUserExpeditionSlotsCount([
+    'user' => $_User,
+]);
 $Slots['FlyingFleetsCount'] = $FlyingFleetsCount;
 $Slots['FlyingExpeditions'] = $FlyingExpeditions;
 if($Slots['FlyingFleetsCount'] >= $Slots['MaxFleetSlots'])

--- a/galaxy.php
+++ b/galaxy.php
@@ -31,7 +31,7 @@ includeLang('galaxy');
 $Time = time();
 $CurrentPlanet = &$_Planet;
 
-$fleetmax = $_User['tech_computer'] + 1 + (($_User['admiral_time'] > 0) ? 2 : 0);
+$fleetmax = $_User['tech_computer'] + 1 + (($_User['admiral_time'] > $Time) ? 2 : 0);
 $CurrentMIP = $CurrentPlanet['interplanetary_missile'];
 $CurrentRC = $CurrentPlanet['recycler'];
 $CurrentSP = $CurrentPlanet['espionage_probe'];

--- a/galaxy.php
+++ b/galaxy.php
@@ -3,7 +3,10 @@
 define('INSIDE', true);
 
 $_EnginePath = './';
-include($_EnginePath.'common.php');
+include($_EnginePath . 'common.php');
+include($_EnginePath . 'modules/flightControl/_includes.php');
+
+use UniEngine\Engine\Modules\FlightControl;
 
 loggedCheck();
 
@@ -31,7 +34,10 @@ includeLang('galaxy');
 $Time = time();
 $CurrentPlanet = &$_Planet;
 
-$fleetmax = $_User['tech_computer'] + 1 + (($_User['admiral_time'] > $Time) ? 2 : 0);
+$fleetmax = FlightControl\Utils\Helpers\getUserFleetSlotsCount([
+    'user' => $_User,
+    'timestamp' => $Time,
+]);
 $CurrentMIP = $CurrentPlanet['interplanetary_missile'];
 $CurrentRC = $CurrentPlanet['recycler'];
 $CurrentSP = $CurrentPlanet['espionage_probe'];

--- a/includes/functions/GalaxyRowUser.php
+++ b/includes/functions/GalaxyRowUser.php
@@ -47,7 +47,7 @@ function GalaxyRowUser($GalaxyRowPlanet, $GalaxyRowUser, $MyBuddies, $SFBStatus)
                 $NameClasses[] = array('class' => 'red', 'importance' => 100);
             }
         }
-        else if(!empty($GalaxyRowUser['activation_code']))
+        else if(!isUserAccountActivated($GalaxyRowUser))
         {
             $Status[] = array('class' => 'nonactivated', 'sign' => $_Lang['User_NonActivated']);
             $NameClasses[] = array('class' => 'nonactivated', 'importance' => 50);

--- a/language/en/fleet.lang
+++ b/language/en/fleet.lang
@@ -213,10 +213,9 @@ $_Lang['fl3_CantSettleNonPlanet']                = 'You cannot colonise a moon n
 $_Lang['fl3_CantSettleNoShips']                  = 'To colonise a planet your have to send at least one Colony ship!';
 $_Lang['fl3_CantRecycleNonDebris']               = 'You cannot recycle debris from a planet or a moon!';
 $_Lang['fl3_CantRecycleNoShip']                  = 'To recycle a debris field you have to send at least one Recycler!';
-$_Lang['fl3_CantDestroyDebris']                  = 'You cannot destroy a debris field!';
 $_Lang['fl3_CantDestroyNonUsed']                 = 'There is no moon to destroy on that coordinates!';
 $_Lang['fl3_CantDestroyYourself']                = 'You cannot destroy your own moon!';
-$_Lang['fl3_CantDestroyNonMoon']                 = 'You cannot destroy a planet!';
+$_Lang['fl3_CantDestroyNonMoon']                 = 'Only moons can be destroyed!';
 $_Lang['fl3_CantDestroyNoShip']                  = 'To destroy a moon you have to send at least one Deathstar!';
 $_Lang['fl3_BadMissionSelected']                 = 'Invalid mission selected!';
 

--- a/language/pl/fleet.lang
+++ b/language/pl/fleet.lang
@@ -212,10 +212,9 @@ $_Lang['fl3_CantSettleNonPlanet']                = 'Nie możesz kolonizować Ksi
 $_Lang['fl3_CantSettleNoShips']                  = 'Aby skolonizować Planetę musisz wysłać Statki Kolonizacyjne!';
 $_Lang['fl3_CantRecycleNonDebris']               = 'Nie możesz zbierać szczątków z Planet ani Księżyców!';
 $_Lang['fl3_CantRecycleNoShip']                  = 'Aby zebrać Pole Zniszczeń musisz wysłać Recyklery!';
-$_Lang['fl3_CantDestroyDebris']                  = 'Nie możesz niszczyć Pola Zniszczeń!';
 $_Lang['fl3_CantDestroyNonUsed']                 = 'Na tej pozycji nie ma Księżyca!';
 $_Lang['fl3_CantDestroyYourself']                = 'Nie możesz niszczyć swojego Księżyca!';
-$_Lang['fl3_CantDestroyNonMoon']                 = 'Nie możesz niszczyć Planet!';
+$_Lang['fl3_CantDestroyNonMoon']                 = 'Nie możesz niszczyć niczego innego prócz księżyców!';
 $_Lang['fl3_CantDestroyNoShip']                  = 'Aby móc zniszczyć Księżyc, musisz wysłać co najmniej jedną Gwiazdę Śmierci!';
 $_Lang['fl3_BadMissionSelected']                 = 'Wybrano niepoprawną Misję!';
 

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -11,6 +11,7 @@ call_user_func(function () {
     include($includePath . './utils/helpers/getFleetUnionJoinData.helper.php');
     include($includePath . './utils/validators/fleetArray.validator.php');
     include($includePath . './utils/validators/joinUnion.validator.php');
+    include($includePath . './utils/validators/missionHold.validator.php');
 
 });
 

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -6,6 +6,7 @@ call_user_func(function () {
 
     $includePath = $_EnginePath . 'modules/flightControl/';
 
+    include($includePath . './utils/helpers/getAvailableSpeeds.helper.php');
     include($includePath . './utils/validators/fleetArray.validator.php');
 
 });

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -9,6 +9,7 @@ call_user_func(function () {
     include($includePath . './utils/fetchers/fetchPlanetOwnerDetails.fetcher.php');
     include($includePath . './utils/helpers/getAvailableHoldTimes.helper.php');
     include($includePath . './utils/helpers/getAvailableSpeeds.helper.php');
+    include($includePath . './utils/helpers/getFleetsInFlightCounters.helper.php');
     include($includePath . './utils/helpers/getFleetUnionJoinData.helper.php');
     include($includePath . './utils/helpers/getUserExpeditionSlotsCount.helper.php');
     include($includePath . './utils/helpers/getUserFleetSlotsCount.helper.php');

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -6,6 +6,7 @@ call_user_func(function () {
 
     $includePath = $_EnginePath . 'modules/flightControl/';
 
+    include($includePath . './utils/helpers/getAvailableHoldTimes.helper.php');
     include($includePath . './utils/helpers/getAvailableSpeeds.helper.php');
     include($includePath . './utils/helpers/getFleetUnionJoinData.helper.php');
     include($includePath . './utils/validators/fleetArray.validator.php');

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -7,6 +7,7 @@ call_user_func(function () {
     $includePath = $_EnginePath . 'modules/flightControl/';
 
     include($includePath . './utils/helpers/getAvailableSpeeds.helper.php');
+    include($includePath . './utils/helpers/getFleetUnionJoinData.helper.php');
     include($includePath . './utils/validators/fleetArray.validator.php');
 
 });

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -6,6 +6,7 @@ call_user_func(function () {
 
     $includePath = $_EnginePath . 'modules/flightControl/';
 
+    include($includePath . './utils/fetchers/fetchPlanetOwnerDetails.fetcher.php');
     include($includePath . './utils/helpers/getAvailableHoldTimes.helper.php');
     include($includePath . './utils/helpers/getAvailableSpeeds.helper.php');
     include($includePath . './utils/helpers/getFleetUnionJoinData.helper.php');

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -10,6 +10,7 @@ call_user_func(function () {
     include($includePath . './utils/helpers/getAvailableSpeeds.helper.php');
     include($includePath . './utils/helpers/getFleetUnionJoinData.helper.php');
     include($includePath . './utils/helpers/getUserFleetSlotsCount.helper.php');
+    include($includePath . './utils/helpers/getValidMissionTypes.helper.php');
     include($includePath . './utils/validators/fleetArray.validator.php');
     include($includePath . './utils/validators/joinUnion.validator.php');
     include($includePath . './utils/validators/missionHold.validator.php');

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -9,6 +9,7 @@ call_user_func(function () {
     include($includePath . './utils/helpers/getAvailableHoldTimes.helper.php');
     include($includePath . './utils/helpers/getAvailableSpeeds.helper.php');
     include($includePath . './utils/helpers/getFleetUnionJoinData.helper.php');
+    include($includePath . './utils/helpers/getUserFleetSlotsCount.helper.php');
     include($includePath . './utils/validators/fleetArray.validator.php');
     include($includePath . './utils/validators/joinUnion.validator.php');
     include($includePath . './utils/validators/missionHold.validator.php');

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -9,6 +9,7 @@ call_user_func(function () {
     include($includePath . './utils/helpers/getAvailableHoldTimes.helper.php');
     include($includePath . './utils/helpers/getAvailableSpeeds.helper.php');
     include($includePath . './utils/helpers/getFleetUnionJoinData.helper.php');
+    include($includePath . './utils/helpers/getUserExpeditionSlotsCount.helper.php');
     include($includePath . './utils/helpers/getUserFleetSlotsCount.helper.php');
     include($includePath . './utils/helpers/getValidMissionTypes.helper.php');
     include($includePath . './utils/validators/fleetArray.validator.php');

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -9,6 +9,7 @@ call_user_func(function () {
     include($includePath . './utils/helpers/getAvailableSpeeds.helper.php');
     include($includePath . './utils/helpers/getFleetUnionJoinData.helper.php');
     include($includePath . './utils/validators/fleetArray.validator.php');
+    include($includePath . './utils/validators/joinUnion.validator.php');
 
 });
 

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -6,6 +6,7 @@ call_user_func(function () {
 
     $includePath = $_EnginePath . 'modules/flightControl/';
 
+    include($includePath . './utils/factories/createFleetDevLogEntry.factory.php');
     include($includePath . './utils/fetchers/fetchPlanetOwnerDetails.fetcher.php');
     include($includePath . './utils/helpers/getAvailableHoldTimes.helper.php');
     include($includePath . './utils/helpers/getAvailableSpeeds.helper.php');

--- a/modules/flightControl/utils/factories/createFleetDevLogEntry.factory.php
+++ b/modules/flightControl/utils/factories/createFleetDevLogEntry.factory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Factories;
+
+/**
+ * @param array $props
+ * @param ref $props['currentPlanet']
+ * @param number $props['newFleetId']
+ * @param number $props['timestamp']
+ * @param array $props['fleetData']
+ * @param number $props['fuelUsage']
+ */
+function createFleetDevLogEntry ($props) {
+    $currentPlanet = &$props['currentPlanet'];
+    $newFleetId = $props['newFleetId'];
+    $timestamp = $props['timestamp'];
+    $fleetData = $props['fleetData'];
+    $fuelUsage = $props['fuelUsage'];
+
+    $entryAdditionalData = [
+        rtrim($fleetData['array'], ';'),
+    ];
+
+    if ($fleetData['resources']['metal'] > 0) {
+        $entryAdditionalData[] = 'M,'.$fleetData['resources']['metal'];
+    }
+    if ($fleetData['resources']['crystal'] > 0) {
+        $entryAdditionalData[] = 'C,'.$fleetData['resources']['crystal'];
+    }
+    if ($fleetData['resources']['deuterium'] > 0) {
+        $entryAdditionalData[] = 'D,'.$fleetData['resources']['deuterium'];
+    }
+    if ($fuelUsage > 0) {
+        $entryAdditionalData[] = 'F,'.$fuelUsage;
+    }
+
+    return [
+        'PlanetID' => $currentPlanet['id'],
+        'Date' => $timestamp,
+        'Place' => 10,
+        'Code' => $fleetData['Mission'],
+        'ElementID' => $newFleetId,
+        'AdditionalData' => implode(';', $entryAdditionalData),
+    ];
+}
+
+?>

--- a/modules/flightControl/utils/fetchers/fetchPlanetOwnerDetails.fetcher.php
+++ b/modules/flightControl/utils/fetchers/fetchPlanetOwnerDetails.fetcher.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Fetchers;
+
+/**
+ * @param array $props
+ * @param ref $props['user']
+ * @param array $props['targetCoordinates']
+ * @param boolean $props['isExtendedUserDetailsEnabled']
+ */
+function fetchPlanetOwnerDetails ($props) {
+    $user = &$props['user'];
+    $targetCoordinates = $props['targetCoordinates'];
+    $isExtendedUserDetailsEnabled = $props['isExtendedUserDetailsEnabled'];
+
+    $userId = $user['id'];
+    $userAllianceId = $user['ally_id'];
+    $isUserInAlliance = ($userAllianceId > 0);
+
+    $query = (
+        "SELECT " .
+        "`planet`.`id` AS `id`, " .
+        "`planet`.`id_owner` AS `owner`, " .
+        "`planet`.`name` AS `name`, " .
+        "`planet`.`quantumgate`, " .
+        "`planetOwnerUser`.`ally_id`, " .
+        "`planetOwnerUser`.`username` AS `username`, " .
+        (
+            $isExtendedUserDetailsEnabled ?
+            (
+                "`planetOwnerUser`.`onlinetime`, " .
+                "`planetOwnerUser`.`user_lastip` as `lastip`, " .
+                "`planetOwnerUser`.`is_onvacation`, " .
+                "`planetOwnerUser`.`is_banned`, " .
+                "`planetOwnerUser`.`authlevel`, " .
+                "`planetOwnerUser`.`first_login`, " .
+                "`planetOwnerUser`.`NoobProtection_EndTime`, " .
+                "`planetOwnerUser`.`multiIP_DeclarationID`, " .
+                "`planetOwnerStats`.`total_rank`, " .
+                "`planetOwnerStats`.`total_points`, "
+            ) :
+            ""
+        ) .
+        "`buddy1`.`active` AS `active1`, " .
+        "`buddy2`.`active` AS `active2` " .
+        (
+            $isUserInAlliance ?
+            (
+                ", " .
+                "`apact1`.`Type` AS `AllyPact1`, " .
+                "`apact2`.`Type` AS `AllyPact2` "
+            ) :
+            ""
+        ) .
+        "FROM {{table}} AS `planet` " .
+        "LEFT JOIN `{{prefix}}buddy` AS `buddy1` " .
+        "ON (`planet`.`id_owner` = `buddy1`.`sender` AND `buddy1`.`owner` = {$userId}) " .
+        "LEFT JOIN `{{prefix}}buddy` AS `buddy2` " .
+        "ON (`planet`.`id_owner` = `buddy2`.`owner` AND `buddy2`.`sender` = {$userId}) " .
+        "LEFT JOIN `{{prefix}}users` AS `planetOwnerUser` " .
+        "ON `planet`.`id_owner` = `planetOwnerUser`.`id` " .
+        (
+            $isUserInAlliance ?
+            (
+                "LEFT JOIN `{{prefix}}ally_pacts` AS `apact1` " .
+                "ON (`apact1`.`AllyID_Sender` = {$userAllianceId} AND `apact1`.`AllyID_Owner` = `planetOwnerUser`.`ally_id` AND `apact1`.`Active` = 1) " .
+                "LEFT JOIN `{{prefix}}ally_pacts` AS `apact2` " .
+                "ON (`apact2`.`AllyID_Sender` = `planetOwnerUser`.`ally_id` AND `apact2`.`AllyID_Owner` = {$userAllianceId} AND `apact2`.`Active` = 1) "
+            ) :
+            ""
+        ) .
+        (
+            $isExtendedUserDetailsEnabled ?
+            (
+                "LEFT JOIN `{{prefix}}statpoints` AS `planetOwnerStats` " .
+                "ON `planet`.`id_owner` = `planetOwnerStats`.`id_owner` AND `stat_type` = '1' "
+            ) :
+            ""
+        ) .
+        "WHERE " .
+        "`planet`.`galaxy` = {$targetCoordinates['galaxy']} AND " .
+        "`planet`.`system` = {$targetCoordinates['system']} AND " .
+        "`planet`.`planet` = {$targetCoordinates['planet']} AND " .
+        "`planet`.`planet_type` = {$targetCoordinates['type']} " .
+        "LIMIT 1 " .
+        ";"
+    );
+
+    $result = doquery($query, 'planets', true);
+
+    return $result;
+}
+
+?>

--- a/modules/flightControl/utils/fetchers/index.php
+++ b/modules/flightControl/utils/fetchers/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/flightControl/utils/helpers/getAvailableHoldTimes.helper.php
+++ b/modules/flightControl/utils/helpers/getAvailableHoldTimes.helper.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Helpers;
+
+/**
+ * @param array $props
+ */
+function getAvailableHoldTimes ($props) {
+    $availableHoldTimes = [
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+    ];
+
+    return $availableHoldTimes;
+}
+
+?>

--- a/modules/flightControl/utils/helpers/getAvailableSpeeds.helper.php
+++ b/modules/flightControl/utils/helpers/getAvailableSpeeds.helper.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Helpers;
+
+/**
+ * @param array $props
+ * @param ref $props['user']
+ * @param number $props['timestamp']
+ */
+function getAvailableSpeeds ($props) {
+    $user = &$props['user'];
+    $timestamp = $props['timestamp'];
+
+    $speedsAvailable = [
+        10,
+        9,
+        8,
+        7,
+        6,
+        5,
+        4,
+        3,
+        2,
+        1,
+    ];
+
+    if ($user['admiral_time'] > $timestamp) {
+        $speedsAvailable[] = 12;
+        $speedsAvailable[] = 11;
+        $speedsAvailable[] = 0.5;
+        $speedsAvailable[] = 0.25;
+    }
+
+    if (MORALE_ENABLED) {
+        $maxSpeedAvailable = max($speedsAvailable);
+
+        if ($user['morale_level'] >= MORALE_BONUS_FLEETSPEEDUP1) {
+            $speedBoostValue = $maxSpeedAvailable + (MORALE_BONUS_FLEETSPEEDUP1_VALUE / 10);
+
+            $speedsAvailable[] = $speedBoostValue;
+        }
+
+        if ($user['morale_level'] >= MORALE_BONUS_FLEETSPEEDUP2) {
+            $speedBoostValue = $maxSpeedAvailable + (MORALE_BONUS_FLEETSPEEDUP2_VALUE / 10);
+
+            $speedsAvailable[] = $speedBoostValue;
+        }
+    }
+
+    rsort($speedsAvailable);
+
+    return $speedsAvailable;
+}
+
+?>

--- a/modules/flightControl/utils/helpers/getFleetUnionJoinData.helper.php
+++ b/modules/flightControl/utils/helpers/getFleetUnionJoinData.helper.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Helpers;
+
+/**
+ * @param array $props
+ * @param array $props['newFleet']
+ */
+function getFleetUnionJoinData ($props) {
+    $newFleet = $props['newFleet'];
+
+    $fetchUnionDataQuery = (
+        "SELECT " .
+        "{{table}}.*, `fleets`.`fleet_send_time` AS `mf_start_time` " .
+        "FROM {{table}} " .
+        "LEFT JOIN {{prefix}}fleets AS `fleets` " .
+        "ON " .
+        "`fleets`.`fleet_id` = {{table}}.`main_fleet_id` " .
+        "WHERE " .
+        "{{table}}.`id` = {$newFleet['ACS_ID']} " .
+        "LIMIT 1 " .
+        ";"
+    );
+    $fetchUnionDataResult = doquery($fetchUnionDataQuery, 'acs', true);
+
+    return $fetchUnionDataResult;
+}
+
+?>

--- a/modules/flightControl/utils/helpers/getFleetsInFlightCounters.helper.php
+++ b/modules/flightControl/utils/helpers/getFleetsInFlightCounters.helper.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Helpers;
+
+/**
+ * @param array $props
+ * @param number $props['userId']
+ */
+function getFleetsInFlightCounters ($props) {
+    $userId = $props['userId'];
+
+    $aggressiveMissionTypes = [ 1, 2, 9 ];
+
+    $counters = [
+        'allFleetsInFlight' => 0,
+        'expeditionsInFlight' => 0,
+        'aggressiveFleetsInFlight' => [
+            'byTargetId' => [],
+            'byTargetOwnerId' => [],
+        ],
+    ];
+
+    $query = (
+        "SELECT " .
+        "`fleet_mission`, `fleet_target_owner`, `fleet_end_id`, `fleet_mess` " .
+        "FROM {{table}} " .
+        "WHERE " .
+        "`fleet_owner` = {$userId} " .
+        ";"
+    );
+    $queryResult = doquery($query, 'fleets');
+
+    while ($fleetData = $queryResult->fetch_assoc()) {
+        $counters['allFleetsInFlight'] += 1;
+
+        if ($fleetData['fleet_mission'] == 15) {
+            $counters['expeditionsInFlight'] += 1;
+        }
+
+        // Don't increment counters if fleet has been already calculated
+        if ($fleetData['fleet_mess'] != 0) {
+            continue;
+        }
+
+        // Skip if fleet is non-aggressive
+        if (!in_array($fleetData['fleet_mission'], $aggressiveMissionTypes)) {
+            continue;
+        }
+
+        $targetId = $fleetData['fleet_end_id'];
+        $targetOwnerId = $fleetData['fleet_target_owner'];
+
+        if (!isset($counters['aggressiveFleetsInFlight']['byTargetId'][$targetId])) {
+            $counters['aggressiveFleetsInFlight']['byTargetId'][$targetId] = 0;
+        }
+        if (!isset($counters['aggressiveFleetsInFlight']['byTargetOwnerId'][$targetOwnerId])) {
+            $counters['aggressiveFleetsInFlight']['byTargetOwnerId'][$targetOwnerId] = 0;
+        }
+
+        $counters['aggressiveFleetsInFlight']['byTargetId'][$targetId] += 1;
+        $counters['aggressiveFleetsInFlight']['byTargetOwnerId'][$targetOwnerId] += 1;
+    }
+
+    return $counters;
+}
+
+?>

--- a/modules/flightControl/utils/helpers/getUserExpeditionSlotsCount.helper.php
+++ b/modules/flightControl/utils/helpers/getUserExpeditionSlotsCount.helper.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Helpers;
+
+use UniEngine\Engine\Includes\Helpers\Users;
+
+/**
+ * @param array $props
+ * @param ref $props['user']
+ */
+function getUserExpeditionSlotsCount ($props) {
+    $user = &$props['user'];
+
+    $expeditionTechLevel = Users\getUsersTechLevel(124, $user);
+
+    return (
+        1 +
+        floor($expeditionTechLevel / 3)
+    );
+}
+
+?>

--- a/modules/flightControl/utils/helpers/getUserFleetSlotsCount.helper.php
+++ b/modules/flightControl/utils/helpers/getUserFleetSlotsCount.helper.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Helpers;
+
+use UniEngine\Engine\Includes\Helpers\Users;
+
+/**
+ * @param array $props
+ * @param ref $props['user']
+ * @param number $props['timestamp']
+ */
+function getUserFleetSlotsCount ($props) {
+    $user = &$props['user'];
+    $timestamp = $props['timestamp'];
+
+    $computerTechLevel = Users\getUsersTechLevel(108, $user);
+    $isAdmiralActive = ($user['admiral_time'] > $timestamp);
+
+    // return 0;
+
+    return (
+        1 +
+        $computerTechLevel +
+        ($isAdmiralActive ? 2 : 0)
+    );
+}
+
+?>

--- a/modules/flightControl/utils/helpers/getUserFleetSlotsCount.helper.php
+++ b/modules/flightControl/utils/helpers/getUserFleetSlotsCount.helper.php
@@ -16,8 +16,6 @@ function getUserFleetSlotsCount ($props) {
     $computerTechLevel = Users\getUsersTechLevel(108, $user);
     $isAdmiralActive = ($user['admiral_time'] > $timestamp);
 
-    // return 0;
-
     return (
         1 +
         $computerTechLevel +

--- a/modules/flightControl/utils/helpers/getValidMissionTypes.helper.php
+++ b/modules/flightControl/utils/helpers/getValidMissionTypes.helper.php
@@ -72,7 +72,10 @@ function getValidMissionTypes ($props) {
     if (!$isPlanetOccupied) {
         $expeditionPlanetCoordinate = (MAX_PLANET_IN_SYSTEM + 1);
 
-        if ($targetCoordinates['planet'] == $expeditionPlanetCoordinate) {
+        if (
+            isFeatureEnabled(\FeatureType::Expeditions) &&
+            $targetCoordinates['planet'] == $expeditionPlanetCoordinate
+        ) {
             $validMissionTypes[] = 15;
         }
 

--- a/modules/flightControl/utils/helpers/getValidMissionTypes.helper.php
+++ b/modules/flightControl/utils/helpers/getValidMissionTypes.helper.php
@@ -10,6 +10,7 @@ namespace UniEngine\Engine\Modules\FlightControl\Utils\Helpers;
  * @param boolean $props['isPlanetOccupied']
  * @param boolean $props['isPlanetOwnedByUser']
  * @param boolean $props['isPlanetOwnedByUsersFriend']
+ * @param boolean $props['isUnionMissionAllowed']
  */
 function getValidMissionTypes ($props) {
     $targetCoordinates = $props['targetCoordinates'];
@@ -18,6 +19,7 @@ function getValidMissionTypes ($props) {
     $isPlanetOccupied = $props['isPlanetOccupied'];
     $isPlanetOwnedByUser = $props['isPlanetOwnedByUser'];
     $isPlanetOwnedByUsersFriend = $props['isPlanetOwnedByUsersFriend'];
+    $isUnionMissionAllowed = $props['isUnionMissionAllowed'];
 
     $validMissionTypes = [];
 
@@ -46,7 +48,10 @@ function getValidMissionTypes ($props) {
 
         if (!$isPlanetOwnedByUser) {
             $validMissionTypes[] = 1;
-            $validMissionTypes[] = 2;
+
+            if ($isUnionMissionAllowed) {
+                $validMissionTypes[] = 2;
+            }
 
             if (
                 $targetCoordinates['type'] == 3 &&

--- a/modules/flightControl/utils/helpers/getValidMissionTypes.helper.php
+++ b/modules/flightControl/utils/helpers/getValidMissionTypes.helper.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Helpers;
+
+/**
+ * @param array $props
+ * @param array $props['targetCoordinates']
+ * @param array $props['fleetShips']
+ * @param number $props['fleetShipsCount']
+ * @param boolean $props['isPlanetOccupied']
+ * @param boolean $props['isPlanetOwnedByUser']
+ * @param boolean $props['isPlanetOwnedByUsersFriend']
+ */
+function getValidMissionTypes ($props) {
+    $targetCoordinates = $props['targetCoordinates'];
+    $fleetShips = $props['fleetShips'];
+    $fleetShipsCount = $props['fleetShipsCount'];
+    $isPlanetOccupied = $props['isPlanetOccupied'];
+    $isPlanetOwnedByUser = $props['isPlanetOwnedByUser'];
+    $isPlanetOwnedByUsersFriend = $props['isPlanetOwnedByUsersFriend'];
+
+    $validMissionTypes = [];
+
+    if ($targetCoordinates['type'] == 2) {
+        if ($fleetShips[209] > 0) {
+            $validMissionTypes[] = 8;
+        }
+
+        // No other valid missions possible for debris field
+        return $validMissionTypes;
+    }
+
+    if ($isPlanetOccupied) {
+        // Transport mission should not be available
+        // when the only ship type available is espionage probe
+        if (
+            !isset($fleetShips[210]) ||
+            $fleetShips[210] < $fleetShipsCount
+        ) {
+            $validMissionTypes[] = 3;
+        }
+
+        if ($isPlanetOwnedByUser) {
+            $validMissionTypes[] = 4;
+        }
+
+        if (!$isPlanetOwnedByUser) {
+            $validMissionTypes[] = 1;
+            $validMissionTypes[] = 2;
+
+            if (
+                $targetCoordinates['type'] == 3 &&
+                isset($fleetShips[214]) &&
+                $fleetShips[214] > 0
+            ) {
+                $validMissionTypes[] = 9;
+            }
+
+            if ($isPlanetOwnedByUsersFriend) {
+                $validMissionTypes[] = 5;
+            }
+
+            if (
+                isset($fleetShips[210]) &&
+                $fleetShips[210] == $fleetShipsCount
+            ) {
+                $validMissionTypes[] = 6;
+            }
+        }
+    }
+
+    if (!$isPlanetOccupied) {
+        $expeditionPlanetCoordinate = (MAX_PLANET_IN_SYSTEM + 1);
+
+        if ($targetCoordinates['planet'] == $expeditionPlanetCoordinate) {
+            $validMissionTypes[] = 15;
+        }
+
+        if ($targetCoordinates['planet'] <= MAX_PLANET_IN_SYSTEM) {
+            if (
+                $targetCoordinates['type'] == 1 &&
+                isset($fleetShips[208]) &&
+                $fleetShips[208] > 0
+            ) {
+                $validMissionTypes[] = 7;
+            }
+        }
+    }
+
+    return $validMissionTypes;
+}
+
+?>

--- a/modules/flightControl/utils/helpers/index.php
+++ b/modules/flightControl/utils/helpers/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/flightControl/utils/validators/joinUnion.validator.php
+++ b/modules/flightControl/utils/validators/joinUnion.validator.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Validators;
+
+use UniEngine\Engine\Modules\FlightControl;
+
+/**
+ * @param array $props
+ * @param array $props['newFleet']
+ * @param array $props['timestamp']
+ * @param ref $props['user']
+ * @param ref $props['destinationEntry']
+ */
+function validateJoinUnion ($props) {
+    $isValid = function () {
+        return [
+            'isValid' => true,
+        ];
+    };
+    $isInvalid = function ($errors) {
+        return [
+            'isValid' => false,
+            'errors' => $errors,
+        ];
+    };
+
+    $newFleet = $props['newFleet'];
+    $timestamp = $props['timestamp'];
+    $user = &$props['user'];
+    $destinationEntry = &$props['destinationEntry'];
+
+    if (!($newFleet['ACS_ID'] > 0)) {
+        return $isInvalid([
+            [ 'errorCode' => 'INVALID_UNION_ID', ],
+        ]);
+    }
+
+    $unionJoinData = FlightControl\Utils\Helpers\getFleetUnionJoinData([
+        'newFleet' => $newFleet,
+    ]);
+
+    if (!($unionJoinData)) {
+        return $isInvalid([
+            [ 'errorCode' => 'UNION_NOT_FOUND', ],
+        ]);
+    }
+
+    if (
+        !(
+            $unionJoinData['owner_id'] == $user['id'] ||
+            strstr($unionJoinData['users'], "|{$user['id']}|") !== false
+        )
+    ) {
+        return $isInvalid([
+            [ 'errorCode' => 'USER_CANT_JOIN', ],
+        ]);
+    }
+
+    if (!($unionJoinData['end_target_id'] == $destinationEntry['id'])) {
+        return $isInvalid([
+            [ 'errorCode' => 'INVALID_DESTINATION_COORDINATES', ],
+        ]);
+    }
+
+    if (!($unionJoinData['fleets_count'] < ACS_MAX_JOINED_FLEETS)) {
+        return $isInvalid([
+            [ 'errorCode' => 'UNION_JOINED_FLEETS_COUNT_EXCEEDED', ],
+        ]);
+    }
+
+    if (!($unionJoinData['start_time'] > $timestamp)) {
+        return $isInvalid([
+            [ 'errorCode' => 'UNION_JOIN_TIME_EXCEEDED', ],
+        ]);
+    }
+
+    return $isValid();
+}
+
+?>

--- a/modules/flightControl/utils/validators/missionHold.validator.php
+++ b/modules/flightControl/utils/validators/missionHold.validator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Validators;
+
+use UniEngine\Engine\Modules\FlightControl;
+
+/**
+ * @param array $props
+ * @param array $props['newFleet']
+ */
+function validateMissionHold ($props) {
+    $isValid = function () {
+        return [
+            'isValid' => true,
+        ];
+    };
+    $isInvalid = function ($errors) {
+        return [
+            'isValid' => false,
+            'errors' => $errors,
+        ];
+    };
+
+    $newFleet = $props['newFleet'];
+
+    $availableHoldTimes = FlightControl\Utils\Helpers\getAvailableHoldTimes([]);
+
+    if (!(in_array($newFleet['HoldTime'], $availableHoldTimes))) {
+        return $isInvalid([
+            [ 'errorCode' => 'INVALID_HOLD_TIME', ],
+        ]);
+    }
+
+    return $isValid();
+}
+
+?>

--- a/overview.php
+++ b/overview.php
@@ -397,8 +397,7 @@ switch($mode)
         }
 
         // --- Activation Box
-        if(!empty($_User['activation_code']))
-        {
+        if (!isUserAccountActivated($_User)) {
             $parse['ActivationInfoBox'] = '<tr><th class="c pad5 orange" colspan="3">'.$_Lang['ActivationInfo_Text'].'</th></tr><tr><th style="visibility: hidden;">&nbsp;</th></tr>';
         }
 

--- a/templates/default_template/fleet2_body.tpl
+++ b/templates/default_template/fleet2_body.tpl
@@ -151,12 +151,7 @@ var AllyPact_AttackWarn = {Insert_AllyPact_AttackWarn};
                         <tr>
                             <th colspan="3">
                             <select name="holdingtime">
-                                <option value="1" {SelectHolding_1}>1</option>
-                                <option value="2" {SelectHolding_2}>2</option>
-                                <option value="4" {SelectHolding_4}>4</option>
-                                <option value="8" {SelectHolding_8}>8</option>
-                                <option value="16" {SelectHolding_16}>16</option>
-                                <option value="32" {SelectHolding_32}>32</option>
+                                {P_HTMLBuilder_MissionHold_AvailableTimes}
                             </select>
                             {fl_expe_hours}
                             </th>


### PR DESCRIPTION
## Summary:

`fleet*.php` files are a huge pile of duplicated code. It's time to extract repeated pieces into reusable functionalities to improve readability (and future modifications), reduce complexity and accidental inconsistencies between subsequent steps.

## Changelog:

- [x] Create shared available flight speeds getter
- [x] Create shared available hold times getter
- [x] Create union flights joining helpers
- [x] Create account activation validator
- [x] Create shared mission type validator
- [x] Create max & available flight slots (overall & expedition) helpers
- [x] Fixed some incorrect admiral time checks
- [x] Simplify transportation ships counter code
- [x] Various cleanups & refactors

## Is migration required?

### NO

## Related issues or PRs:

- #139