### PR TITLE
Allow to logout when account is locked because activation has not been completed

### DIFF
--- a/common.php
+++ b/common.php
@@ -122,7 +122,13 @@ if(isLogged()) {
         [ 'timestamp' => $Common_TimeNow ]
     );
 
-    if ($isUserBlockedByActivationRequirement) {
+    if (
+        (
+            !isset($_DontCheckAccountActivation) ||
+            $_DontCheckAccountActivation != true
+        ) &&
+        $isUserBlockedByActivationRequirement
+    ) {
         $_DontShowMenus = true;
         message($_Lang['NonActiveBlock'], $_GameConfig['game_name']);
     }

--- a/common.php
+++ b/common.php
@@ -130,7 +130,11 @@ if(isLogged()) {
         $isUserBlockedByActivationRequirement
     ) {
         $_DontShowMenus = true;
-        message($_Lang['NonActiveBlock'], $_GameConfig['game_name']);
+
+        message(
+            prepareActivationLockMessageHTML(),
+            $_GameConfig['game_name']
+        );
     }
 
     $userCookieBlockadeResult = handleUserBlockadeByCookie(

--- a/includes/per_module/common/userdata_helpers.php
+++ b/includes/per_module/common/userdata_helpers.php
@@ -275,4 +275,14 @@ function prepareVacationModeMessageHTML (&$user, $params) {
     return parsetemplate($tpl, $tplData);
 }
 
+/**
+ * @return String HTML of the message
+ */
+function prepareActivationLockMessageHTML () {
+    $tplData = includeLang('common_activationlock', true);
+    $tpl = gettemplate('common_activationlock');
+
+    return parsetemplate($tpl, $tplData);
+}
+
 ?>

--- a/language/en/common_activationlock.lang
+++ b/language/en/common_activationlock.lang
@@ -1,0 +1,8 @@
+<?php
+
+$_Lang['ActivationLock_Message_General']    = 'You have to activate your account to continue your game play. Checkout your email account to find your account\'s activation link in the mail we\'ve sent to you upon registration.';
+$_Lang['ActivationLock_Message_Warning']    = 'If your account will remain inactive for 7 days past the registration date, it will be automatically removed!';
+
+$_Lang['ActivationLock_Btns_Logout']        = 'Logout';
+
+?>

--- a/language/en/system.lang
+++ b/language/en/system.lang
@@ -61,7 +61,6 @@ $_Lang['Chrono_PrettyTime']                     = [
 $_Lang['FatalError_PlanetRowEmpty']             = 'Critical error! Mother planet data unavailable!<br/>Please report this problem!';
 $_Lang['ServerStart_NotReached']                = 'This game server is going to be opened on <b class="lime">%s</b> at <b class="lime">%s</b>!<br/>In the meantime, you can invite other players using your referral link...';
 $_Lang['ServerIsClosed']                        = 'Game server is currently offline (disabled by Administration)!';
-$_Lang['NonActiveBlock']                        = '<b class="orange">You have to activate your account to continue your game play. Checkout your email account to find your account\'s activation link in the mail we\'ve sent to you upon registration.</b><br/>If your account will remain inactive for 7 days past the registration date, it will be automatically removed!';
 
 $_Lang['PlanetList_MoonChar']                   = 'M';
 $_Lang['PlanetList_TypeChange_Sign_M']          = 'M';

--- a/language/fr/common_activationlock.lang
+++ b/language/fr/common_activationlock.lang
@@ -1,0 +1,5 @@
+<?php
+
+include("{$_EnginePath}language/en/common_activationlock.lang");
+
+?>

--- a/language/pl/common_activationlock.lang
+++ b/language/pl/common_activationlock.lang
@@ -1,0 +1,8 @@
+<?php
+
+$_Lang['ActivationLock_Message_General']    = 'Aby móc kontynuować rozgrywkę, musisz aktywować swoje konto poprzez Link Aktywacyjny otrzymany w Wiadomości EMail!';
+$_Lang['ActivationLock_Message_Warning']    = 'Jeśli twoje konto pozostanie nieaktywne przez 7 dni od daty rejestracji, zostanie ono usunięte z Systemu!';
+
+$_Lang['ActivationLock_Btns_Logout']        = 'Wyloguj';
+
+?>

--- a/language/pl/system.lang
+++ b/language/pl/system.lang
@@ -62,7 +62,6 @@ $_Lang['Chrono_PrettyTime'] = [
 $_Lang['FatalError_PlanetRowEmpty'] = 'Błąd krytyczny! Brak danych o Planecie Matce!<br/>Prosimy zgłosić to do Administracji!';
 $_Lang['ServerStart_NotReached']    = 'Ten Serwer Gry zostanie uruchomiony <b class="lime">%s</b> o godzinie <b class="lime">%s</b>!<br/>Do czasu rozpoczęcia gry, możesz zapraszać swoich znajomych przez otrzymany Link Polecający...';
 $_Lang['ServerIsClosed']            = 'Serwer został wyłączony przez Administrację!';
-$_Lang['NonActiveBlock']            = '<b class="orange">Aby móc kontynuować rozgrywkę, musisz aktywować swoje konto poprzez Link Aktywacyjny otrzymany w Wiadomości EMail!</b><br/>Jeśli twoje konto pozostanie nieaktywne przez 7 dni od daty rejestracji, zostanie ono usunięte z Systemu!';
 
 $_Lang['PlanetList_MoonChar']           = 'K';
 $_Lang['PlanetList_TypeChange_Sign_M']  = 'K';

--- a/logout.php
+++ b/logout.php
@@ -6,6 +6,7 @@ $_AllowInVacationMode = true;
 $_DontCheckPolls = true;
 $_DontShowMenus = true;
 $_DontForceRulesAcceptance = true;
+$_DontCheckAccountActivation = true;
 
 $_EnginePath = './';
 include($_EnginePath.'common.php');

--- a/logout.php
+++ b/logout.php
@@ -2,6 +2,7 @@
 
 define('INSIDE', true);
 
+$_UseMinimalCommon = true;
 $_AllowInVacationMode = true;
 $_DontCheckPolls = true;
 $_DontShowMenus = true;

--- a/templates/default_template/common_activationlock.tpl
+++ b/templates/default_template/common_activationlock.tpl
@@ -1,0 +1,12 @@
+<b class="orange">
+    {ActivationLock_Message_General}
+</b>
+<br/>
+<span>
+    {ActivationLock_Message_Warning}
+</span>
+<br/>
+<br/>
+<a href="logout.php">
+    {ActivationLock_Btns_Logout}
+</a>


### PR DESCRIPTION
Closes #80 

Changelog:
- [x] Logout is now possible even without activating the account
- [x] Account lock (activation message) allows to log out (a link is shown)
- [x] Account lock message has been moved to a template (simplified translation string)