### PR TITLE
Refactor fleet missions' code | Part 18 | Noob protection validator

### DIFF
--- a/ajax/sendmissiles.php
+++ b/ajax/sendmissiles.php
@@ -166,36 +166,22 @@ if($PlanetData['id_owner'] > 0)
         ]);
 
         if (!$noobProtectionValidationResult['isSuccess']) {
-            switch ($noobProtectionValidationResult['error']['code']) {
-                case 'ATTACKER_STATISTICS_UNAVAILABLE':
-                    CreateReturn('663');
-                    break;
-                case 'TARGET_STATISTICS_UNAVAILABLE':
-                    CreateReturn('662');
-                    break;
-                case 'ATTACKER_NOOBPROTECTION_ENDTIME_NOT_REACHED':
-                    CreateReturn('653');
-                    break;
-                case 'TARGET_NEVER_LOGGED_IN':
-                    CreateReturn('655');
-                    break;
-                case 'TARGET_NOOBPROTECTION_ENDTIME_NOT_REACHED':
-                    CreateReturn('654');
-                    break;
-                case 'ATTACKER_NOOBPROTECTION_BASIC_LIMIT_NOT_REACHED':
-                    CreateReturn('657');
-                    break;
-                case 'TARGET_NOOBPROTECTION_BASIC_LIMIT_NOT_REACHED':
-                    // TODO: This should have a separate error message
-                    CreateReturn('656');
-                    break;
-                case 'TARGET_NOOBPROTECTION_TOO_WEAK_BY_MULTIPLIER':
-                    CreateReturn('656');
-                    break;
-                case 'ATTACKER_NOOBPROTECTION_TOO_WEAK_BY_MULTIPLIER':
-                    CreateReturn('658');
-                    break;
-            }
+            $mapNoobProtectionErrorsToAjaxErrorCodes = [
+                'ATTACKER_STATISTICS_UNAVAILABLE'                   => '663',
+                'TARGET_STATISTICS_UNAVAILABLE'                     => '662',
+                'ATTACKER_NOOBPROTECTION_ENDTIME_NOT_REACHED'       => '653',
+                'TARGET_NEVER_LOGGED_IN'                            => '655',
+                'TARGET_NOOBPROTECTION_ENDTIME_NOT_REACHED'         => '654',
+                'ATTACKER_NOOBPROTECTION_BASIC_LIMIT_NOT_REACHED'   => '657',
+                // TODO: This should have a separate error message
+                'TARGET_NOOBPROTECTION_BASIC_LIMIT_NOT_REACHED'     => '656',
+                'TARGET_NOOBPROTECTION_TOO_WEAK_BY_MULTIPLIER'      => '656',
+                'ATTACKER_NOOBPROTECTION_TOO_WEAK_BY_MULTIPLIER'    => '658',
+            ];
+
+            $errorCode = $noobProtectionValidationResult['error']['code'];
+
+            CreateReturn($mapNoobProtectionErrorsToAjaxErrorCodes[$errorCode]);
         }
     }
     if((CheckAuth('supportadmin') OR CheckAuth('supportadmin', AUTHCHECK_NORMAL, $HeDBRec)) AND $adminprotection == 1)

--- a/ajax/sendmissiles.php
+++ b/ajax/sendmissiles.php
@@ -156,53 +156,45 @@ if($PlanetData['id_owner'] > 0)
     }
     $HeGameLevel = $HeDBRec['total_points'];
 
-    if($protection == 1)
-    {
-        if($_User['total_rank'] < 1)
-        {
-            CreateReturn('663');
-        }
-        if($HeDBRec['total_rank'] < 1)
-        {
-            CreateReturn('662');
-        }
+    if ($protection == 1) {
+        $noobProtectionValidationResult = FlightControl\Utils\Validators\validateNoobProtection([
+            'attackerUser' => $_User,
+            'attackerStats' => $MyGameLevel,
+            'targetUser' => $HeDBRec,
+            'targetStats' => $HeGameLevel,
+            'currentTimestamp' => $Now,
+        ]);
 
-        if($_User['NoobProtection_EndTime'] > $Now)
-        {
-            CreateReturn('653');
-        }
-        else if($HeDBRec['first_login'] == 0)
-        {
-            CreateReturn('655');
-        }
-        else if($HeDBRec['NoobProtection_EndTime'] > $Now)
-        {
-            CreateReturn('654');
-        }
-
-        if($HeDBRec['onlinetime'] >= ($Now - (TIME_DAY * $noIdleProtect)))
-        {
-            if($HeGameLevel < ($protectiontime * 1000))
-            {
-                CreateReturn('656');
-            }
-            else if($MyGameLevel < ($protectiontime * 1000))
-            {
-                CreateReturn('657');
-            }
-            else
-            {
-                if($MyGameLevel < ($noNoobProtect * 1000) OR $HeGameLevel < ($noNoobProtect * 1000))
-                {
-                    if(($MyGameLevel > ($HeGameLevel * $protectionmulti)))
-                    {
-                        CreateReturn('656');
-                    }
-                    else if(($MyGameLevel * $protectionmulti) < $HeGameLevel)
-                    {
-                        CreateReturn('658');
-                    }
-                }
+        if (!$noobProtectionValidationResult['isSuccess']) {
+            switch ($noobProtectionValidationResult['error']['code']) {
+                case 'ATTACKER_STATISTICS_UNAVAILABLE':
+                    CreateReturn('663');
+                    break;
+                case 'TARGET_STATISTICS_UNAVAILABLE':
+                    CreateReturn('662');
+                    break;
+                case 'ATTACKER_NOOBPROTECTION_ENDTIME_NOT_REACHED':
+                    CreateReturn('653');
+                    break;
+                case 'TARGET_NEVER_LOGGED_IN':
+                    CreateReturn('655');
+                    break;
+                case 'TARGET_NOOBPROTECTION_ENDTIME_NOT_REACHED':
+                    CreateReturn('654');
+                    break;
+                case 'ATTACKER_NOOBPROTECTION_BASIC_LIMIT_NOT_REACHED':
+                    CreateReturn('657');
+                    break;
+                case 'TARGET_NOOBPROTECTION_BASIC_LIMIT_NOT_REACHED':
+                    // TODO: This should have a separate error message
+                    CreateReturn('656');
+                    break;
+                case 'TARGET_NOOBPROTECTION_TOO_WEAK_BY_MULTIPLIER':
+                    CreateReturn('656');
+                    break;
+                case 'ATTACKER_NOOBPROTECTION_TOO_WEAK_BY_MULTIPLIER':
+                    CreateReturn('658');
+                    break;
             }
         }
     }

--- a/modules/flightControl/_includes.php
+++ b/modules/flightControl/_includes.php
@@ -23,11 +23,13 @@ call_user_func(function () {
     include($includePath . './utils/validators/fleetArray.validator.php');
     include($includePath . './utils/validators/joinUnion.validator.php');
     include($includePath . './utils/validators/missionHold.validator.php');
+    include($includePath . './utils/validators/noobProtection.validator.php');
     include($includePath . './utils/validators/quantumGate.validator.php');
     include($includePath . './utils/validators/smartFleetsBlockadeState.validator.php');
     include($includePath . './utils/errors/bashLimit.utils.php');
     include($includePath . './utils/errors/fleetArray.utils.php');
     include($includePath . './utils/errors/joinUnion.utils.php');
+    include($includePath . './utils/errors/noobProtection.utils.php');
     include($includePath . './utils/errors/quantumGate.utils.php');
     include($includePath . './utils/errors/smartFleetsBlockade.utils.php');
 

--- a/modules/flightControl/utils/errors/noobProtection.utils.php
+++ b/modules/flightControl/utils/errors/noobProtection.utils.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Errors;
+
+/**
+ * @param object $error As returned by FlightControl\Utils\Validators\validateNoobProtection
+ */
+function mapNoobProtectionValidationErrorToReadableMessage($error) {
+    global $_Lang;
+
+    $errorCode = $error['code'];
+    $errorParams = $error['params'];
+
+    $knownErrorsByCode = [
+        'ATTACKER_STATISTICS_UNAVAILABLE' => $_Lang['fl3_ProtectURStatNotCalc'],
+        'TARGET_STATISTICS_UNAVAILABLE' => $_Lang['fl3_ProtectHIStatNotCalc'],
+        'ATTACKER_NOOBPROTECTION_ENDTIME_NOT_REACHED' => function ($params) use (&$_Lang) {
+            return sprintf(
+                $_Lang['fl3_ProtectNewTimeYou'],
+                pretty_time($params['timeLeft'])
+            );
+        },
+        'TARGET_NEVER_LOGGED_IN' => $_Lang['fl3_ProtectNewTimeHe2'],
+        'TARGET_NOOBPROTECTION_ENDTIME_NOT_REACHED' => function ($params) use (&$_Lang) {
+            return sprintf(
+                $_Lang['fl3_ProtectNewTimeHe'],
+                pretty_time($params['timeLeft'])
+            );
+        },
+        'ATTACKER_NOOBPROTECTION_BASIC_LIMIT_NOT_REACHED' => function ($params) use (&$_Lang) {
+            return sprintf(
+                $_Lang['fl3_ProtectURWeak'],
+                prettyNumber($params['basicLimit'])
+            );
+        },
+        'TARGET_NOOBPROTECTION_BASIC_LIMIT_NOT_REACHED' => function ($params) use (&$_Lang) {
+            return sprintf(
+                $_Lang['fl3_ProtectHIWeak'],
+                prettyNumber($params['basicLimit'])
+            );
+        },
+        'TARGET_NOOBPROTECTION_TOO_WEAK_BY_MULTIPLIER' => function ($params) use (&$_Lang) {
+            return sprintf(
+                $_Lang['fl3_ProtectUR2Strong'],
+                prettyNumber($params['weakMultiplier'])
+            );
+        },
+        'ATTACKER_NOOBPROTECTION_TOO_WEAK_BY_MULTIPLIER' => function ($params) use (&$_Lang) {
+            return sprintf(
+                $_Lang['fl3_ProtectHI2Strong'],
+                prettyNumber($params['weakMultiplier'])
+            );
+        },
+    ];
+
+    if (is_callable($knownErrorsByCode[$errorCode])) {
+        return $knownErrorsByCode[$errorCode]($errorParams);
+    }
+
+    return $knownErrorsByCode[$errorCode];
+}
+
+?>

--- a/modules/flightControl/utils/validators/noobProtection.validator.php
+++ b/modules/flightControl/utils/validators/noobProtection.validator.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace UniEngine\Engine\Modules\FlightControl\Utils\Validators;
+
+use UniEngine\Engine\Modules\FlightControl;
+
+/**
+ * @param array $props
+ * @param object $props['attackerUser']
+ * @param object $props['attackerStats']
+ * @param object $props['targetUser']
+ * @param object $props['targetStats']
+ * @param number $props['currentTimestamp']
+ */
+function validateNoobProtection($validationParams) {
+    global $_GameConfig;
+
+    $protectionConfig = [
+        'fixedBasicProtectionLimit' => $_GameConfig['noobprotectiontime'] * 1000,
+        'noIdleProtectionTime' => $_GameConfig['no_idle_protect'] * TIME_DAY,
+        'weakProtectionFinalLimit' => $_GameConfig['no_noob_protect'] * 1000,
+        'weakProtectionMultiplier' => $_GameConfig['noobprotectionmulti'],
+    ];
+
+    $validator = function ($input, $resultHelpers) use ($protectionConfig) {
+        $attackerUser = &$input['attackerUser'];
+        $attackerStats = $input['attackerStats'];
+        $targetUser = &$input['targetUser'];
+        $targetStats = $input['targetStats'];
+        $currentTimestamp = $input['currentTimestamp'];
+
+        if ($attackerUser['total_rank'] < 1) {
+            return $resultHelpers['createFailure']([
+                'code' => 'ATTACKER_STATISTICS_UNAVAILABLE',
+            ]);
+        }
+        if ($targetUser['total_rank'] < 1) {
+            return $resultHelpers['createFailure']([
+                'code' => 'TARGET_STATISTICS_UNAVAILABLE',
+            ]);
+        }
+        if ($attackerUser['NoobProtection_EndTime'] > $currentTimestamp) {
+            return $resultHelpers['createFailure']([
+                'code' => 'ATTACKER_NOOBPROTECTION_ENDTIME_NOT_REACHED',
+                'params' => [
+                    'endTime' => $attackerUser['NoobProtection_EndTime'],
+                    'timeLeft' => ($attackerUser['NoobProtection_EndTime'] - $currentTimestamp),
+                ],
+            ]);
+        }
+        if ($targetUser['first_login'] == 0) {
+            return $resultHelpers['createFailure']([
+                'code' => 'TARGET_NEVER_LOGGED_IN',
+            ]);
+        }
+        if ($targetUser['NoobProtection_EndTime'] > $currentTimestamp) {
+            return $resultHelpers['createFailure']([
+                'code' => 'TARGET_NOOBPROTECTION_ENDTIME_NOT_REACHED',
+                'params' => [
+                    'endTime' => $targetUser['NoobProtection_EndTime'],
+                    'timeLeft' => ($targetUser['NoobProtection_EndTime'] - $currentTimestamp),
+                ],
+            ]);
+        }
+        if ($attackerStats < $protectionConfig['fixedBasicProtectionLimit']) {
+            return $resultHelpers['createFailure']([
+                'code' => 'ATTACKER_NOOBPROTECTION_BASIC_LIMIT_NOT_REACHED',
+                'params' => [
+                    'basicLimit' => $protectionConfig['fixedBasicProtectionLimit'],
+                ],
+            ]);
+        }
+
+        if ($targetUser['onlinetime'] < ($currentTimestamp - $protectionConfig['noIdleProtectionTime'])) {
+            return $resultHelpers['createSuccess']([
+                'isTargetIdle' => true,
+            ]);
+        }
+
+        if ($targetStats < $protectionConfig['fixedBasicProtectionLimit']) {
+            return $resultHelpers['createFailure']([
+                'code' => 'TARGET_NOOBPROTECTION_BASIC_LIMIT_NOT_REACHED',
+                'params' => [
+                    'basicLimit' => $protectionConfig['fixedBasicProtectionLimit'],
+                ],
+            ]);
+        }
+
+        if (
+            $targetStats >= $protectionConfig['weakProtectionFinalLimit'] &&
+            $attackerStats >= $protectionConfig['weakProtectionFinalLimit']
+        ) {
+            return $resultHelpers['createSuccess']([
+                'isTargetIdle' => false,
+            ]);
+        }
+
+        if ($attackerStats > ($targetStats * $protectionConfig['weakProtectionMultiplier'])) {
+            return $resultHelpers['createFailure']([
+                'code' => 'TARGET_NOOBPROTECTION_TOO_WEAK_BY_MULTIPLIER',
+                'params' => [
+                    'weakMultiplier' => $protectionConfig['weakProtectionMultiplier'],
+                ],
+            ]);
+        }
+        if ($targetStats > ($attackerStats * $protectionConfig['weakProtectionMultiplier'])) {
+            return $resultHelpers['createFailure']([
+                'code' => 'ATTACKER_NOOBPROTECTION_TOO_WEAK_BY_MULTIPLIER',
+                'params' => [
+                    'weakMultiplier' => $protectionConfig['weakProtectionMultiplier'],
+                ],
+            ]);
+        }
+
+        return $resultHelpers['createSuccess']([
+            'isTargetIdle' => false,
+        ]);
+    };
+
+    return createFuncWithResultHelpers($validator)($validationParams);
+}
+
+?>


### PR DESCRIPTION
## Summary:

...

## Changelog:

- [x] Move noob protection checks into a separate validator
- [x] Both sending fleet & sending missiles should use the new noob protection validator
- [x] Fix: when sending missiles, attackers basic protection limit should be checked regardless of whether the target is considered idle and not under protection
 
## Related issues or PRs:

- #91 
