### PR TITLE
GH-230 | Overview - Alert components (part 1)

### DIFF
--- a/language/en/overview.lang
+++ b/language/en/overview.lang
@@ -116,7 +116,7 @@ $_Lang['MsgBox_Msgs']                = 'messages';
 
 // New Polls
 $_Lang['PollBox_You_can_vote_in_new_polls']  = 'There %s new poll%s which %s awaiting your vote%s!';
-$_Lang['PollBox_One']                        = array('is', '', 'is', '');
+$_Lang['PollBox_One']                        = array('is a', '', 'is', '');
 $_Lang['PollBox_More']                       = array('are', 's', 'are', 's');
 
 // ServerInformations

--- a/language/pl/overview.lang
+++ b/language/pl/overview.lang
@@ -221,7 +221,7 @@ $_Lang['ProAccBuyNext']         = 'Wznów';
 $_Lang['AdminAlertsBox']        = 'Masz <a style="color: black;" href="admin/report_list.php">%s nowych Raportów</a>, <a style="color: black;" href="admin/declare_list.php">%s nowych Deklaracji</a> i <a style="color: black;" href="admin/alerts_list.php">%s nowych Alertów Systemowych</a> do przejrzenia!';
 
 $_Lang['MailChange_Title']      = 'Proces Zmiany Adresu Email';
-$_Lang['MailChange_Text']       = '<b style="color: lime;">Na twoim koncie został aktywowany proces zmiany Adresu Email. Aby zakończyć ten proces, musisz potwierdzić aktywność Nowego Adresu Email oraz rzeczywistą chęć zmiany ze Starego Adresu Email.<br/>Jeśli nie użyjesz Linku Aktywacyjnego wysłanego na Stary Adres Email (np. przez brak dostępu do tej skrzynki), będziesz mógł zrobić to po 7 dniach od rozpoczęcią procesu w tym miejscu.</b>';
+$_Lang['MailChange_Text']       = '<b style="color: lime;">Na twoim koncie został aktywowany proces zmiany Adresu Email. Aby zakończyć ten proces, musisz potwierdzić aktywność Nowego Adresu Email oraz rzeczywistą chęć zmiany ze Starego Adresu Email.<br/>Jeśli nie użyjesz Linku Aktywacyjnego wysłanego na Stary Adres Email (np. przez brak dostępu do tej skrzynki), będziesz mógł zrobić to po 7 dniach od rozpoczęcia procesu w tym miejscu.</b>';
 $_Lang['MailChange_Inf1']       = 'Nie potwierdziłeś jeszcze aktywności Nowego Adresu Email!';
 $_Lang['MailChange_Inf2']       = 'Potwierdzenie zmiany Adresu będzie możliwe dnia %s z tego miejsca<br/>(lub wcześniej, jeśli użyjesz Linku Aktywacyjnego wysłanego na Stary Adres Email)';
 $_Lang['MailChange_Buto']       = 'Zakończ Proces Zmiany Adresu Email';

--- a/modules/overview/_includes.php
+++ b/modules/overview/_includes.php
@@ -24,6 +24,7 @@ call_user_func(function () {
     include($includePath . './screens/FirstLogin/utils/effects/updateUserOnFirstLogin.effect.php');
     include($includePath . './screens/FirstLogin/utils/helpers/getReferrerTasksData.helper.php');
 
+    include($includePath . './screens/Overview/components/AdminAlerts/AdminAlerts.component.php');
     include($includePath . './screens/Overview/components/PlanetsListElement/PlanetsListElement.component.php');
     include($includePath . './screens/Overview/components/ResourcesTransport/ResourcesTransport.component.php');
     include($includePath . './screens/Overview/components/StatsList/StatsList.component.php');

--- a/modules/overview/_includes.php
+++ b/modules/overview/_includes.php
@@ -26,6 +26,7 @@ call_user_func(function () {
 
     include($includePath . './screens/Overview/components/AdminAlerts/AdminAlerts.component.php');
     include($includePath . './screens/Overview/components/EmailChangeInfo/EmailChangeInfo.component.php');
+    include($includePath . './screens/Overview/components/NewMessagesInfo/NewMessagesInfo.component.php');
     include($includePath . './screens/Overview/components/PlanetsListElement/PlanetsListElement.component.php');
     include($includePath . './screens/Overview/components/ResourcesTransport/ResourcesTransport.component.php');
     include($includePath . './screens/Overview/components/StatsList/StatsList.component.php');

--- a/modules/overview/_includes.php
+++ b/modules/overview/_includes.php
@@ -25,6 +25,7 @@ call_user_func(function () {
     include($includePath . './screens/FirstLogin/utils/helpers/getReferrerTasksData.helper.php');
 
     include($includePath . './screens/Overview/components/AdminAlerts/AdminAlerts.component.php');
+    include($includePath . './screens/Overview/components/EmailChangeInfo/EmailChangeInfo.component.php');
     include($includePath . './screens/Overview/components/PlanetsListElement/PlanetsListElement.component.php');
     include($includePath . './screens/Overview/components/ResourcesTransport/ResourcesTransport.component.php');
     include($includePath . './screens/Overview/components/StatsList/StatsList.component.php');

--- a/modules/overview/_includes.php
+++ b/modules/overview/_includes.php
@@ -27,6 +27,7 @@ call_user_func(function () {
     include($includePath . './screens/Overview/components/AdminAlerts/AdminAlerts.component.php');
     include($includePath . './screens/Overview/components/EmailChangeInfo/EmailChangeInfo.component.php');
     include($includePath . './screens/Overview/components/NewMessagesInfo/NewMessagesInfo.component.php');
+    include($includePath . './screens/Overview/components/NewSurveysInfo/NewSurveysInfo.component.php');
     include($includePath . './screens/Overview/components/PlanetsListElement/PlanetsListElement.component.php');
     include($includePath . './screens/Overview/components/ResourcesTransport/ResourcesTransport.component.php');
     include($includePath . './screens/Overview/components/StatsList/StatsList.component.php');

--- a/modules/overview/screens/Overview/components/AdminAlerts/AdminAlerts.component.php
+++ b/modules/overview/screens/Overview/components/AdminAlerts/AdminAlerts.component.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Overview\Screens\Overview\Components\AdminAlerts;
+
+/**
+ * @param array $props
+ * @param arrayRef $props['user']
+ */
+function render($props) {
+    global $_Lang;
+
+    $hasAccess = CheckAuth(
+        'supportadmin',
+        AUTHCHECK_NORMAL,
+        $props['user']
+    );
+
+    if (!$hasAccess) {
+        return [
+            'componentHTML' => '',
+        ];
+    }
+
+    $localTemplateLoader = createLocalTemplateLoader(__DIR__);
+
+    $getAlertsCountsQuery = (
+        (
+            "SELECT " .
+            "COUNT(*) AS `count`, " .
+            "'reports' AS `type` " .
+            "FROM `{{prefix}}reports` " .
+            "WHERE " .
+            "`status` = 0 "
+        ) .
+        "UNION " .
+        (
+            "SELECT " .
+            "COUNT(*) AS `count`, " .
+            "'declarations' AS `type` " .
+            "FROM `{{prefix}}declarations` " .
+            "WHERE " .
+            "`status` = 0 "
+        ) .
+        "UNION " .
+        (
+            "SELECT " .
+            "COUNT(*) AS `count`, " .
+            "'system_alerts' AS `type` " .
+            "FROM `{{prefix}}system_alerts` " .
+            "WHERE " .
+            "`status` = 0 "
+        )
+    );
+    $getAlertsCountsResult = doquery($getAlertsCountsQuery, '');
+
+    $alertsCounts = mapQueryResults($getAlertsCountsResult, function ($counter) {
+        return $counter;
+    });
+    $alertsCounts = object_map($alertsCounts, function ($counter) {
+        return [
+            $counter['count'],
+            $counter['type']
+        ];
+    });
+    $totalAlertsCount = array_sum($alertsCounts);
+
+    if ($totalAlertsCount <= 0) {
+        return [
+            'componentHTML' => '',
+        ];
+    }
+
+    $tplBodyParams = [
+        'content' => sprintf(
+            $_Lang['AdminAlertsBox'],
+            $alertsCounts['reports'],
+            $alertsCounts['declarations'],
+            $alertsCounts['system_alerts']
+        ),
+    ];
+    $tplBodyParams = array_merge($_Lang, $tplBodyParams);
+
+    $componentHTML = parsetemplate(
+        $localTemplateLoader('body'),
+        $tplBodyParams
+    );
+
+    return [
+        'componentHTML' => $componentHTML,
+    ];
+}
+
+?>

--- a/modules/overview/screens/Overview/components/AdminAlerts/AdminAlerts.component.php
+++ b/modules/overview/screens/Overview/components/AdminAlerts/AdminAlerts.component.php
@@ -7,6 +7,12 @@ namespace UniEngine\Engine\Modules\Overview\Screens\Overview\Components\AdminAle
  * @param arrayRef $props['user']
  */
 function render($props) {
+    $adminAlertTypes = [
+        'REPORTS' => 'reports',
+        'DECLARATIONS' => 'declarations',
+        'SYSTEM_ALERTS' => 'system_alerts',
+    ];
+
     global $_Lang;
 
     $hasAccess = CheckAuth(
@@ -27,7 +33,7 @@ function render($props) {
         (
             "SELECT " .
             "COUNT(*) AS `count`, " .
-            "'reports' AS `type` " .
+            "'{$adminAlertTypes['REPORTS']}' AS `type` " .
             "FROM `{{prefix}}reports` " .
             "WHERE " .
             "`status` = 0 "
@@ -36,7 +42,7 @@ function render($props) {
         (
             "SELECT " .
             "COUNT(*) AS `count`, " .
-            "'declarations' AS `type` " .
+            "'{$adminAlertTypes['DECLARATIONS']}' AS `type` " .
             "FROM `{{prefix}}declarations` " .
             "WHERE " .
             "`status` = 0 "
@@ -45,7 +51,7 @@ function render($props) {
         (
             "SELECT " .
             "COUNT(*) AS `count`, " .
-            "'system_alerts' AS `type` " .
+            "'{$adminAlertTypes['SYSTEM_ALERTS']}' AS `type` " .
             "FROM `{{prefix}}system_alerts` " .
             "WHERE " .
             "`status` = 0 "
@@ -73,9 +79,9 @@ function render($props) {
     $tplBodyParams = [
         'content' => sprintf(
             $_Lang['AdminAlertsBox'],
-            $alertsCounts['reports'],
-            $alertsCounts['declarations'],
-            $alertsCounts['system_alerts']
+            $alertsCounts[$adminAlertTypes['REPORTS']],
+            $alertsCounts[$adminAlertTypes['DECLARATIONS']],
+            $alertsCounts[$adminAlertTypes['SYSTEM_ALERTS']]
         ),
     ];
     $tplBodyParams = array_merge($_Lang, $tplBodyParams);

--- a/modules/overview/screens/Overview/components/AdminAlerts/body.tpl
+++ b/modules/overview/screens/Overview/components/AdminAlerts/body.tpl
@@ -1,0 +1,12 @@
+<tr>
+    <th
+        style="border-color: #FFA366; background-color: #FF8533; color: black;"
+        class="c pad2"
+        colspan="3"
+    >
+        {content}
+    </th>
+</tr>
+<tr>
+    <th class="inv">&nbsp;</th>
+</tr>

--- a/modules/overview/screens/Overview/components/AdminAlerts/index.php
+++ b/modules/overview/screens/Overview/components/AdminAlerts/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/overview/screens/Overview/components/EmailChangeInfo/EmailChangeInfo.component.php
+++ b/modules/overview/screens/Overview/components/EmailChangeInfo/EmailChangeInfo.component.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Overview\Screens\Overview\Components\EmailChangeInfo;
+
+/**
+ * @param array $props
+ * @param arrayRef $props['user']
+ * @param number $props['currentTimestamp']
+ */
+function render($props) {
+    global $_Lang;
+
+    $user = &$props['user'];
+    $currentTimestamp = $props['currentTimestamp'];
+
+    if ($user['email'] == $user['email_2']) {
+        return [
+            'componentHTML' => '',
+        ];
+    }
+
+    $getEmailChangeDataQuery = (
+        "SELECT " .
+        "* " .
+        "FROM {{table}} " .
+        "WHERE " .
+        "`UserID` = {$user['id']} AND " .
+        "`ConfirmType` = 0 " .
+        "LIMIT 1 " .
+        ";"
+    );
+    $emailChangeData = doquery($getEmailChangeDataQuery, 'mailchange', true);
+
+    if (!$emailChangeData) {
+        return [
+            'componentHTML' => '',
+        ];
+    }
+
+    $localTemplateLoader = createLocalTemplateLoader(__DIR__);
+
+    $changeEndTimestamp = $emailChangeData['Date'] + (TIME_DAY * 7);
+    $hasConfirmedNewAddress = ($emailChangeData['ConfirmHashNew'] == '');
+    $hasChangeTimePassed = ($changeEndTimestamp < $currentTimestamp);
+
+    $tplBodyParams = [
+        'ChangeProcess_HideFormStyle' => (
+            ($hasConfirmedNewAddress && $hasChangeTimePassed) ?
+                '' :
+                'display: none;'
+        ),
+        'ChangeProcess_Status' => (
+            !$hasConfirmedNewAddress ?
+                $_Lang['MailChange_Inf1'] :
+                (
+                    !$hasChangeTimePassed ?
+                        sprintf(
+                            $_Lang['MailChange_Inf2'],
+                            date('d.m.Y H:i:s', $changeEndTimestamp)
+                        ) :
+                        ''
+                )
+        ),
+    ];
+    $tplBodyParams = array_merge($_Lang, $tplBodyParams);
+
+    $componentHTML = parsetemplate(
+        $localTemplateLoader('body'),
+        $tplBodyParams
+    );
+
+    return [
+        'componentHTML' => $componentHTML,
+    ];
+}
+
+?>

--- a/modules/overview/screens/Overview/components/EmailChangeInfo/body.tpl
+++ b/modules/overview/screens/Overview/components/EmailChangeInfo/body.tpl
@@ -1,0 +1,28 @@
+<tbody>
+    <tr>
+        <td colspan="3" class="c">
+            {MailChange_Title}
+        </td>
+    </tr>
+    <tr>
+        <th colspan="3" class="c">
+            {MailChange_Text}
+            <br/><br/>
+            {ChangeProcess_Status}
+            <form
+                action="email_change.php?hash=none"
+                method="post"
+                style="{ChangeProcess_HideFormStyle}"
+            >
+                <input
+                    type="submit"
+                    style="font-weight: bold;"
+                    value="{MailChange_Buto}"
+                />
+            </form>
+        </th>
+    </tr>
+    <tr>
+        <th class="inv">&nbsp;</th>
+    </tr>
+</tbody>

--- a/modules/overview/screens/Overview/components/EmailChangeInfo/index.php
+++ b/modules/overview/screens/Overview/components/EmailChangeInfo/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/overview/screens/Overview/components/NewMessagesInfo/NewMessagesInfo.component.php
+++ b/modules/overview/screens/Overview/components/NewMessagesInfo/NewMessagesInfo.component.php
@@ -62,7 +62,6 @@ function render($props) {
     $tplBodyParams = [
         'content' => $content,
     ];
-    $tplBodyParams = array_merge($_Lang, $tplBodyParams);
 
     $componentHTML = parsetemplate(
         $localTemplateLoader('body'),

--- a/modules/overview/screens/Overview/components/NewMessagesInfo/NewMessagesInfo.component.php
+++ b/modules/overview/screens/Overview/components/NewMessagesInfo/NewMessagesInfo.component.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Overview\Screens\Overview\Components\NewMessagesInfo;
+
+/**
+ * @param array $props
+ * @param number $props['userId']
+ */
+function render($props) {
+    global $_Lang;
+
+    $userId = $props['userId'];
+
+    $getMessagesDataQuery = (
+        "SELECT " .
+        "COUNT(`id`) as `count` " .
+        "FROM {{table}} " .
+        "WHERE " .
+        "`deleted` = false AND " .
+        "`read` = false AND " .
+        "`id_owner` = {$userId} " .
+        ";"
+    );
+    $messagesData = doquery($getMessagesDataQuery, 'messages', true);
+
+    if (
+        !$messagesData ||
+        $messagesData['count'] == 0
+    ) {
+        return [
+            'componentHTML' => '',
+        ];
+    }
+
+    $localTemplateLoader = createLocalTemplateLoader(__DIR__);
+
+    /**
+     * TODO: This counting logic is strictly related to Polish rules for countable things.
+     * In the future, use a better translation system to remove that and bring better support for other languages.
+     */
+    if ($messagesData['count'] == 1) {
+        $msgBoxNew_suffix = $_Lang['MsgBox_New_1'];
+        $msgBoxUnread_suffix = $_Lang['MsgBox_Unreaden_1'];
+        $msgBoxCounter_variant = $_Lang['MsgBox_Msg'];
+    } else if (
+        $messagesData['count'] > 1 &&
+        $messagesData['count'] < 5
+    ) {
+        $msgBoxNew_suffix = $_Lang['MsgBox_New_2_4'];
+        $msgBoxUnread_suffix = $_Lang['MsgBox_Unreaden_2_4'];
+        $msgBoxCounter_variant = $_Lang['MsgBox_Msgs'];
+    } else {
+        $msgBoxNew_suffix = $_Lang['MsgBox_New_5'];
+        $msgBoxUnread_suffix = $_Lang['MsgBox_Unreaden_5'];
+        $msgBoxCounter_variant = $_Lang['MsgBox_Msgs'];
+    }
+
+    $newMessagesCount = prettyNumber($messagesData['count']);
+
+    $content = "{$_Lang['MsgBox_YouHave']} {$newMessagesCount} {$_Lang['MsgBox_New']}{$msgBoxNew_suffix}, {$_Lang['MsgBox_Unreaden']}{$msgBoxUnread_suffix} {$msgBoxCounter_variant}!";
+
+    $tplBodyParams = [
+        'content' => $content,
+    ];
+    $tplBodyParams = array_merge($_Lang, $tplBodyParams);
+
+    $componentHTML = parsetemplate(
+        $localTemplateLoader('body'),
+        $tplBodyParams
+    );
+
+    return [
+        'componentHTML' => $componentHTML,
+    ];
+}
+
+?>

--- a/modules/overview/screens/Overview/components/NewMessagesInfo/body.tpl
+++ b/modules/overview/screens/Overview/components/NewMessagesInfo/body.tpl
@@ -1,0 +1,7 @@
+<tr>
+    <th colspan="3">
+        <a href="messages.php">
+            {content}
+        </a>
+    </th>
+</tr>

--- a/modules/overview/screens/Overview/components/NewMessagesInfo/index.php
+++ b/modules/overview/screens/Overview/components/NewMessagesInfo/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/modules/overview/screens/Overview/components/NewSurveysInfo/NewSurveysInfo.component.php
+++ b/modules/overview/screens/Overview/components/NewSurveysInfo/NewSurveysInfo.component.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace UniEngine\Engine\Modules\Overview\Screens\Overview\Components\NewSurveysInfo;
+
+/**
+ * @param array $props
+ * @param number $props['userId']
+ */
+function render($props) {
+    global $_Lang;
+
+    $userId = $props['userId'];
+
+    $getSurveysDataQuery = (
+        "SELECT " .
+        "`surveys`.`id`, `votes`.`id` AS `vote_id` " .
+        "FROM {{table}} AS `surveys` " .
+        "LEFT JOIN {{prefix}}poll_votes AS `votes` " .
+        "ON " .
+        "`votes`.`poll_id` = `surveys`.`id` AND " .
+        "`votes`.`user_id` = {$userId} " .
+        "WHERE " .
+        "`surveys`.`open` = 1 " .
+        "ORDER BY `surveys`.`time` DESC " .
+        ";"
+    );
+    $surveysData = doquery($getSurveysDataQuery, 'polls');
+
+    $surveysWithoutVotes = mapQueryResults($surveysData, function ($surveyEntry) {
+        $hasUserVoted = ($surveyEntry['vote_id'] > 0);
+
+        return (
+            $hasUserVoted ?
+                0 :
+                1
+        );
+    });
+    $surveysWithoutVotesCount = array_sum($surveysWithoutVotes);
+
+    if ($surveysWithoutVotesCount == 0) {
+        return [
+            'componentHTML' => '',
+        ];
+    }
+
+    $localTemplateLoader = createLocalTemplateLoader(__DIR__);
+
+    /**
+     * TODO: Use a better translation system to support more languages.
+     */
+    $content = vsprintf(
+        $_Lang['PollBox_You_can_vote_in_new_polls'],
+        (
+            $surveysWithoutVotesCount > 1 ?
+                $_Lang['PollBox_More'] :
+                $_Lang['PollBox_One']
+        )
+    );
+
+    $tplBodyParams = [
+        'content' => $content,
+    ];
+
+    $componentHTML = parsetemplate(
+        $localTemplateLoader('body'),
+        $tplBodyParams
+    );
+
+    return [
+        'componentHTML' => $componentHTML,
+    ];
+}
+
+?>

--- a/modules/overview/screens/Overview/components/NewSurveysInfo/body.tpl
+++ b/modules/overview/screens/Overview/components/NewSurveysInfo/body.tpl
@@ -1,0 +1,7 @@
+<tr>
+    <th colspan="3">
+        <a style="color: orange;" href="polls.php">
+            {content}
+        </a>
+    </th>
+</tr>

--- a/modules/overview/screens/Overview/components/NewSurveysInfo/index.php
+++ b/modules/overview/screens/Overview/components/NewSurveysInfo/index.php
@@ -1,0 +1,5 @@
+<?php
+
+header("Location: ../index.php");
+
+?>

--- a/overview.php
+++ b/overview.php
@@ -94,33 +94,10 @@ switch($mode)
         ])['componentHTML'];
 
         // --- MailChange Box ------------------------------------------------------------------------------------
-        $parse['MailChange_Hide'] = 'display: none;';
-        if($_User['email'] != $_User['email_2'])
-        {
-            $MailChange = doquery("SELECT * FROM {{table}} WHERE `UserID` = {$_User['id']} AND `ConfirmType` = 0 LIMIT 1;", 'mailchange', true);
-            if($MailChange['ID'] > 0)
-            {
-                $ChangeTime = $MailChange['Date'] + (TIME_DAY * 7);
-
-                $parse['MailChange_Hide'] = '';
-                $parse['MailChange_Box'] = sprintf($_Lang['MailChange_Text']);
-                if($MailChange['ConfirmHashNew'] == '')
-                {
-                    if($ChangeTime < $Now)
-                    {
-                        $parse['MailChange_Box'] .= "<br/><br/><form action=\"email_change.php?hash=none\" method=\"post\"><input type=\"submit\" style=\"font-weight: bold;\" value=\"{$_Lang['MailChange_Buto']}\" /></form>";
-                    }
-                    else
-                    {
-                        $parse['MailChange_Box'] .= "<br/><br/>".sprintf($_Lang['MailChange_Inf2'], date('d.m.Y H:i:s', $ChangeTime));
-                    }
-                }
-                else
-                {
-                    $parse['MailChange_Box'] .= "<br/><br/>{$_Lang['MailChange_Inf1']}";
-                }
-            }
-        }
+        $parse['EmailChangeInfoBox'] = Overview\Screens\Overview\Components\EmailChangeInfo\render([
+            'user' => &$_User,
+            'currentTimestamp' => $Now,
+        ])['componentHTML'];
 
         // Fleet Blockade Info (here, only for Global Block)
         $parse['P_SFBInfobox'] = FlightControl\Components\SmartFleetBlockadeInfoBox\render()['componentHTML'];

--- a/overview.php
+++ b/overview.php
@@ -89,26 +89,9 @@ switch($mode)
         }
 
         // --- Admin Info Box ------------------------------------------------------------------------------------
-        if(CheckAuth('supportadmin'))
-        {
-            $Query_AdminBoxCheck[] = "SELECT COUNT(*) AS `Count`, 1 AS `Type` FROM `{{prefix}}reports` WHERE `status` = 0";
-            $Query_AdminBoxCheck[] = "SELECT COUNT(*) AS `Count`, 2 AS `Type` FROM `{{prefix}}declarations` WHERE `status` = 0";
-            $Query_AdminBoxCheck[] = "SELECT COUNT(*) AS `Count`, 3 AS `Type` FROM `{{prefix}}system_alerts` WHERE `status` = 0";
-            $Query_AdminBoxCheck = implode(' UNION ', $Query_AdminBoxCheck);
-            $Result_AdminBoxCheck = doquery($Query_AdminBoxCheck, '');
-
-            $AdminBoxTotalCount = 0;
-            while($AdminBoxData = $Result_AdminBoxCheck->fetch_assoc())
-            {
-                $AdminBox[$AdminBoxData['Type']] = $AdminBoxData['Count'];
-                $AdminBoxTotalCount += $AdminBoxData['Count'];
-            }
-            if($AdminBoxTotalCount > 0)
-            {
-                $AdminAlerts = sprintf($_Lang['AdminAlertsBox'], $AdminBox[1], $AdminBox[2], $AdminBox[3]);
-                $parse['AdminInfoBox'] = '<tr><th style="border-color: #FFA366; background-color: #FF8533; color: black;" class="c pad2" colspan="3">'.$AdminAlerts.'</th></tr><tr><th class="inv">&nbsp;</th></tr>';
-            }
-        }
+        $parse['AdminInfoBox'] = Overview\Screens\Overview\Components\AdminAlerts\render([
+            'user' => &$_User,
+        ])['componentHTML'];
 
         // --- MailChange Box ------------------------------------------------------------------------------------
         $parse['MailChange_Hide'] = 'display: none;';

--- a/overview.php
+++ b/overview.php
@@ -136,22 +136,9 @@ switch($mode)
         ])['componentHTML'];
 
         // --- New Polls Information Box -------------------------------------------------------------------------
-        $SQLResult_GetPolls = doquery("SELECT {{table}}.`id`, `votes`.`id` AS `vote_id` FROM {{table}} LEFT JOIN {{prefix}}poll_votes AS `votes` ON `votes`.`poll_id` = {{table}}.id AND `votes`.`user_id` = {$_User['id']} WHERE {{table}}.`open` = 1 ORDER BY {{table}}.`time` DESC;", 'polls');
-        if($SQLResult_GetPolls->num_rows > 0)
-        {
-            $AvailablePolls = 0;
-            while($PollData = $SQLResult_GetPolls->fetch_assoc())
-            {
-                if($PollData['vote_id'] <= 0)
-                {
-                    $AvailablePolls += 1;
-                }
-            }
-            if($AvailablePolls > 0)
-            {
-                $parse['NewPollsBox'] = '<tr><th colspan="3"><a style="color: orange;" href="polls.php">'.vsprintf($_Lang['PollBox_You_can_vote_in_new_polls'], ($AvailablePolls > 1) ? $_Lang['PollBox_More'] : $_Lang['PollBox_One']).'</a></th></tr>';
-            }
-        }
+        $parse['NewPollsBox'] = Overview\Screens\Overview\Components\NewSurveysInfo\render([
+            'userId' => $_User['id'],
+        ])['componentHTML'];
 
         // --- Get users activity informations -----------------------------------------------------------
         $TodaysStartTimeStamp = mktime(0, 0, 0);

--- a/overview.php
+++ b/overview.php
@@ -131,32 +131,9 @@ switch($mode)
         }
 
         // --- New Messages Information Box ----------------------------------------------------------------------
-        $NewMsg = doquery("SELECT COUNT(`id`) as `count` FROM {{table}} WHERE `deleted` = false AND `read` = false AND `id_owner` = {$_User['id']};", 'messages', true);
-        if($NewMsg['count'] > 0)
-        {
-            if($NewMsg['count'] == 1)
-            {
-                $MsgBox_NewSurfix = $_Lang['MsgBox_New_1'];
-                $MsgBox_UnreadenSurfix= $_Lang['MsgBox_Unreaden_1'];
-                $MsgBox_Msg_s = $_Lang['MsgBox_Msg'];
-            }
-            elseif($NewMsg['count'] > 1 AND $NewMsg['count'] < 5)
-            {
-                $MsgBox_NewSurfix = $_Lang['MsgBox_New_2_4'];
-                $MsgBox_UnreadenSurfix= $_Lang['MsgBox_Unreaden_2_4'];
-                $MsgBox_Msg_s = $_Lang['MsgBox_Msgs'];
-            }
-            else
-            {
-                $MsgBox_NewSurfix = $_Lang['MsgBox_New_5'];
-                $MsgBox_UnreadenSurfix= $_Lang['MsgBox_Unreaden_5'];
-                $MsgBox_Msg_s = $_Lang['MsgBox_Msgs'];
-            }
-            $MsgBoxText = $_Lang['MsgBox_YouHave'].' '.prettyNumber($NewMsg['count']).' '.$_Lang['MsgBox_New'].$MsgBox_NewSurfix.', '.$_Lang['MsgBox_Unreaden'].$MsgBox_UnreadenSurfix.' '.$MsgBox_Msg_s.'!';
-
-            $NewMsgBox = '<tr><th colspan="3"><a href="messages.php">'.$MsgBoxText.'</a></th></tr>';
-            $parse['NewMsgBox'] = $NewMsgBox;
-        }
+        $parse['NewMsgBox'] = Overview\Screens\Overview\Components\NewMessagesInfo\render([
+            'userId' => $_User['id'],
+        ])['componentHTML'];
 
         // --- New Polls Information Box -------------------------------------------------------------------------
         $SQLResult_GetPolls = doquery("SELECT {{table}}.`id`, `votes`.`id` AS `vote_id` FROM {{table}} LEFT JOIN {{prefix}}poll_votes AS `votes` ON `votes`.`poll_id` = {{table}}.id AND `votes`.`user_id` = {$_User['id']} WHERE {{table}}.`open` = 1 ORDER BY {{table}}.`time` DESC;", 'polls');

--- a/templates/default_template/overview_body.tpl
+++ b/templates/default_template/overview_body.tpl
@@ -26,17 +26,7 @@ $(document).ready(function()
 <br />
 {P_SFBInfobox}
 <table width="750">
-    <tbody style="{MailChange_Hide}">
-        <tr>
-            <td colspan="3" class="c">{MailChange_Title}</td>
-        </tr>
-        <tr>
-            <th colspan="3" class="c">{MailChange_Box}</th>
-        </tr>
-        <tr>
-            <th class="inv">&nbsp;</th>
-        </tr>
-    </tbody>
+    {EmailChangeInfoBox}
     {VacationModeBox}
     {ActivationInfoBox}
     {NewUserBox}


### PR DESCRIPTION
## Summary:

Overview screen has a lot of components that should have their own (sub)modules, let's refactor this.

## Changelog:

- [x] Move admin info box to a component
- [x] Move email change info box to a component
- [x] Move unread messages info box to a component
- [x] Move surveys info box to a component
- [x] Fix minor typos here and there

## Related issues or PRs:

#230 

